### PR TITLE
mapping EDBB to EDDB

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,9 +10,9 @@ Installer moves imageformats/ to application data directory
 
 Known problems:
  * Some APP (or TWR) stations are covering multiple airfields. We are 
-   currently not able to reflect this correctly. But we map EDBB_APP
-   to EDDI, NY to KLGA and MSK to UUDD in order to at least show
-   the positions in the right place.
+   currently not able to reflect this correctly. But we map NY to KLGA
+   and MSK to UUDD in order to at least show the positions in the right
+   place.
 
 Version 2.1.13.1beta
  fixed:

--- a/src/BookedController.cpp
+++ b/src/BookedController.cpp
@@ -141,7 +141,7 @@ QString BookedController::getApproach() const {
     if(list.last().startsWith("APP") || list.last().startsWith("DEP")) {
         // map special callsigns to airports. Still not perfect, because only 1 airport gets matched this way...
         if(list.first() == "EDBB")
-            return "EDDI"; // map EDBB -> EDDI
+            return "EDDB"; // map EDBB -> EDDB (no other active airfields covered by this sector)
         if(list.first() == "NY")
             return "KLGA"; // map NY -> KLGA
         if(list.first() == "MSK")

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -119,7 +119,7 @@ QString Controller::getApproach() const {
     if(list.last().startsWith("APP") || list.last().startsWith("DEP")) {
         // map special callsigns to airports. Still not perfect, because only 1 airport gets matched this way...
         if(list.first() == "EDBB")
-            return "EDDI"; // map EDBB -> EDDI
+            return "EDDB"; // map EDBB -> EDDB (no other active airfields covered by this sector)
         else if(list.first() == "NY")
             return "KLGA"; // map NY -> KLGA
         else if(list.first() == "MSK")


### PR DESCRIPTION
As Tegel/EDDT closed on 8 November 2020 and Tegel CTR was revoked,
there are no further active airfields covered by EDBB, only EDDB
is covered from now on. However, APP/DEP/DIR stations will remain
named EDBB instead of EDDB on VATSIM in the near future, so the
mapping is not removed yet but redirected to the correct place.