### PR TITLE
Adjust QuteScoop to the new VATSIM Format

### DIFF
--- a/src/BookedController.cpp
+++ b/src/BookedController.cpp
@@ -12,17 +12,17 @@
 
 BookedController::BookedController(const QJsonObject& json, const WhazzupData* whazzup):
         Client(json, whazzup) {
-    /*sector = 0;
+    sector = 0;
 
     // extra booking values
-    bookingType = field(stringList, 4).toInt();
-    timeTo = field(stringList, 14);
-    date = field(stringList, 16);
+    bookingType = json["bookingType"].toInt();
+    timeTo = json["timeTo"].toString();
+    date = json["date"].toString();
     //always some miracle "1" here: getField(stringList, 19); ??
-    link = field(stringList, 35);
+    link = json["link"].toString();
     if(!link.isEmpty() && !link.contains("http://"))
         link = QString("http://%1").arg(link);
-    timeFrom = field(stringList, 37);
+    timeFrom = json["timeFrom"].toString();
 
     // default
     countryCode = "";
@@ -101,7 +101,7 @@ BookedController::BookedController(const QJsonObject& json, const WhazzupData* w
     atisMessage = "";
     timeLastAtisReceived = QDateTime();
     voiceServer = "";
-    server = "";*/
+    server = "";
 }
 
 QString BookedController::facilityString() const {

--- a/src/BookedController.cpp
+++ b/src/BookedController.cpp
@@ -8,9 +8,11 @@
 #include "NavData.h"
 #include "Settings.h"
 
-BookedController::BookedController(const QStringList& stringList, const WhazzupData* whazzup):
-        Client(stringList, whazzup) {
-    sector = 0;
+#include <QJsonObject>
+
+BookedController::BookedController(const QJsonObject& json, const WhazzupData* whazzup):
+        Client(json, whazzup) {
+    /*sector = 0;
 
     // extra booking values
     bookingType = field(stringList, 4).toInt();
@@ -99,7 +101,7 @@ BookedController::BookedController(const QStringList& stringList, const WhazzupD
     atisMessage = "";
     timeLastAtisReceived = QDateTime();
     voiceServer = "";
-    server = "";
+    server = "";*/
 }
 
 QString BookedController::facilityString() const {

--- a/src/BookedController.h
+++ b/src/BookedController.h
@@ -9,12 +9,14 @@
 #include "WhazzupData.h"
 #include "ClientDetails.h"
 
+#include <QJsonObject>
+
 class WhazzupData;
 class Sector;
 
 class BookedController: public Client {
     public:
-        BookedController(const QStringList& stringList, const WhazzupData* whazzup);
+        BookedController(const QJsonObject& json, const WhazzupData* whazzup);
 
         bool isObserver() const { return facilityType == 0; }
         bool isATC() const { return facilityType > 0; } // facilityType = 1 is reported for FSS stations and staff (at least from VATSIM)

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -59,8 +59,6 @@ QString Client::displayName(bool withLink) const {
 }
 
 QString Client::clientInformation() const {
-    if(!clientSoftware.isEmpty())
-        return clientSoftware + " " + clientVersion;
     return QString();
 }
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -8,35 +8,18 @@
 #include "Settings.h"
 
 
-Client::Client(const QStringList& stringList, const WhazzupData* whazzup) {
-    label = field(stringList, 0);
-    userId = field(stringList, 1);
-    realName = field(stringList, 2);
-    lat = field(stringList, 5).toDouble();
-    lon = field(stringList, 6).toDouble();
-    server = field(stringList, 14);
-    protrevision = field(stringList, 15).toInt();
-    rating = field(stringList, 16).toInt();
-    timeConnected = QDateTime::fromString(field(stringList, 37), "yyyyMMddHHmmss");
-    timeConnected.setTimeSpec(Qt::UTC);
+Client::Client(const QJsonObject& json, const WhazzupData* whazzup) {
+    label = json["callsign"].toString();
+    userId = QString::number(json["cid"].toInt());
+    realName = json["name"].toString();
+    lat = json["latitude"].toDouble();
+    lon = json["longitude"].toDouble();
+    server = json["server"].toString();
+    protrevision = 0; // Not included in the JSON data
+    rating = json["rating"].toInt();
+    timeConnected = QDateTime::fromString(json["logon_time"].toString(), Qt::ISODate);
 
-    if(whazzup->isIvao()) {
-        clientSoftware = field(stringList, 38); // IVAO only
-        clientVersion = field(stringList, 39); // IVAO only
-        adminRating = field(stringList, 40).toInt(); // IVAO only
-        rating = field(stringList, 41).toInt(); // IVAO only
-    }
-
-    if(whazzup->isVatsim())
-        network = VATSIM;
-    else if(whazzup->isIvao())
-        network = IVAO;
-    else
-        network = OTHER;
-
-    // un-fuck user names. people enter all kind of stuff here
-    realName.remove(QRegExp("[_\\-\\d\\.\\,\\;\\:\\#\\+\\(\\)]"));
-    realName = realName.trimmed();
+    network = VATSIM;
 
     if(realName.contains(QRegExp("\\b[A-Z]{4}$"))) {
         homeBase = realName.right(4);

--- a/src/Client.h
+++ b/src/Client.h
@@ -15,7 +15,7 @@
 
 class Client: public MapObject {
     public:
-        enum Network { IVAO, VATSIM, OTHER };
+        enum Network { VATSIM, OTHER };
 
         Client(const QJsonObject& json, const WhazzupData *whazzup);
 
@@ -36,7 +36,6 @@ class Client: public MapObject {
         QDateTime timeConnected;
 
         int adminRating, rating;
-        QString clientSoftware, clientVersion; // IVAO only
 
         Network network;
 

--- a/src/Client.h
+++ b/src/Client.h
@@ -11,11 +11,13 @@
 #include "WhazzupData.h"
 #include "ClientDetails.h"
 
+#include <QJsonDocument>
+
 class Client: public MapObject {
     public:
         enum Network { IVAO, VATSIM, OTHER };
 
-        Client(const QStringList& stringList, const WhazzupData *whazzup);
+        Client(const QJsonObject& json, const WhazzupData *whazzup);
 
         virtual QString toolTip() const;
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -12,34 +12,24 @@
 #include "Settings.h"
 #include "helpers.h"
 
+#include <QJsonObject>
 
-Controller::Controller(const QStringList& stringList, const WhazzupData* whazzup):
-        Client(stringList, whazzup),
+Controller::Controller(const QJsonObject& json, const WhazzupData* whazzup):
+        Client(json, whazzup),
         sector(0) {
-    frequency = field(stringList, 4);
-    facilityType = field(stringList, 18).toInt();
+
+    frequency = json["frequency"].toString();
+    facilityType = json["facility"].toInt();
     if(label.right(4) == "_FSS") facilityType = 7; // workaround as VATSIM reports 1 for _FSS
 
-    visualRange = field(stringList, 19).toInt();
-    atisMessage = field(stringList, 35);
-    timeLastAtisReceived = QDateTime::fromString(field(stringList, 36), "yyyyMMddHHmmss");
-
-    QStringList atisLines = atisMessage.split(QString::fromUtf8("^§")); // needed due to source encoded in UTF8 -
-                                                                        // found after some headache...
-
-    if(network== Client::IVAO) {
-        voiceChannel = atisLines.first();
-        atisLines.removeFirst();
-    }
-
+    visualRange = json["visual_range"].toInt();
+    timeLastAtisReceived = QDateTime::fromString(json["last_updated"].toString(), Qt::ISODate);
 
     atisMessage = "";
-    while (!atisLines.isEmpty()) {
-        QString line = atisLines.takeFirst();
-        if (line.startsWith("$ "))
-            voiceChannel = line.mid(2);
-        else
-            atisMessage += line + "<br>";
+    if(json.contains("text_atis") && json["text_atis"].isArray()) {
+        QJsonArray atis = json["text_atis"].toArray();
+        for(int i = 0; i < atis.size(); ++i)
+            atisMessage += atis[i].toString() + " <br>";
     }
 
     // do some magic for Controller Info like "online until"...

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -70,8 +70,13 @@ Controller::Controller(const QJsonObject& json, const WhazzupData* whazzup):
             } else
                 icao = icao.left(p);
         }
-        if(NavData::instance()->sectors.contains(icao) && !icao.isEmpty())
+        if(NavData::instance()->sectors.contains(icao) && !icao.isEmpty()) {
             this->sector = NavData::instance()->sectors[icao];
+            // The new VATSIM Data format doesn't provide data on controller position, so we'll need to average out the positions in the sector
+            QPair<double, double> center = this->sector->getCenter();
+            this->lat = center.first;
+            this->lon = center.second;
+        }
     }
 }
 

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -11,11 +11,13 @@
 #include "Sector.h"
 #include "Airport.h"
 
+#include <QJsonObject>
+
 class Airport;
 
 class Controller: public Client {
     public:
-        Controller(const QStringList& stringList, const WhazzupData* whazzup);
+        Controller(const QJsonObject& json, const WhazzupData* whazzup);
 
         virtual void showDetailsDialog();
 

--- a/src/ListClientsDialogModel.cpp
+++ b/src/ListClientsDialogModel.cpp
@@ -34,7 +34,6 @@ QVariant ListClientsDialogModel::headerData(int section, enum Qt::Orientation or
         case 7: return QString("Pilot:\nroute DEST");
         case 8: return QString("Pilot:\nflight type");
         case 9: return QString("Pilot:\nroute dist [NM]");
-        case 10: return QString("Admin Rating"); //IVAO only
     }
 
     return QVariant();
@@ -106,7 +105,7 @@ int ListClientsDialogModel::rowCount(const QModelIndex &parent) const {
 
 int ListClientsDialogModel::columnCount(const QModelIndex &parent) const {
     Q_UNUSED(parent);
-    return Whazzup::instance()->realWhazzupData().isIvao()? 11: 10;
+    return 10;
 }
 
 void ListClientsDialogModel::modelSelected(const QModelIndex& index) {

--- a/src/Pilot.h
+++ b/src/Pilot.h
@@ -59,17 +59,14 @@ class Pilot: public Client {
         QString planAircraft, planTAS, planDep, planAlt, planDest,
         planAltAirport, planRevision, planFlighttype, planDeptime,
         transponder, planRemarks, planRoute, planActtime, airline,
-        planAltAirport2, planTypeOfFlight, // IVAO only
         qnh_inHg, qnh_mb, // VATSIM only
         routeWaypointsPlanDepCache, routeWaypointsPlanDestCache,
         routeWaypointsPlanRouteCache;
         QDate dayOfFlight;
         int altitude, groundspeed, planEnroute_hrs, planEnroute_mins,
-        planFuel_hrs, planFuel_mins,
-        pob; // IVAO only
+        planFuel_hrs, planFuel_mins;
         double trueHeading;
-        bool onGround, // IVAO only
-        showDepDestLine;
+        bool showDepDestLine;
         QDateTime whazzupTime; // need some local reference to that
         QList<Waypoint*> routeWaypointsCache; // caching calculated routeWaypoints
     private:

--- a/src/Pilot.h
+++ b/src/Pilot.h
@@ -11,6 +11,8 @@
 #include "Client.h"
 #include "Waypoint.h"
 
+#include <QJsonDocument>
+
 class Airport;
 
 class Pilot: public Client {
@@ -20,7 +22,7 @@ class Pilot: public Client {
             GROUND_ARR, BLOCKED, CRASHED, BUSH, PREFILED
         };
 
-        Pilot(const QStringList& stringList, const WhazzupData* whazzup);
+        Pilot(const QJsonObject& json, const WhazzupData* whazzup);
 
         virtual QString toolTip() const;
         virtual QString rank() const;

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -422,15 +422,11 @@ void PreferencesDialog::on_cbNetwork_currentIndexChanged(int index) {
     Settings::setDownloadNetwork(index);
 
     switch(index) {
-    case 0: // IVAO
-        Settings::setStatusLocation("http://www.ivao.aero/whazzup/status.txt");
-        gbDownloadBookings->setChecked(false);
-        break;
-    case 1: // VATSIM
+    case 0: // VATSIM
         Settings::setStatusLocation("http://status.vatsim.net/");
         gbDownloadBookings->setChecked(true);
         break;
-    case 2: // user defined
+    case 1: // user defined
         Settings::setStatusLocation(editUserDefinedLocation->text());
         gbDownloadBookings->setChecked(false);
         break;

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -45,8 +45,8 @@ void PreferencesDialog::loadSettings() {
     cbDownloadPeriodically->setChecked(Settings::downloadPeriodically());
     cbNetwork->setCurrentIndex(Settings::downloadNetwork());
     editUserDefinedLocation->setText(Settings::userDownloadLocation());
-    editUserDefinedLocation->setEnabled(Settings::downloadNetwork() == 2);
-    lbluserDefinedLocation->setEnabled(Settings::downloadNetwork() == 2);
+    editUserDefinedLocation->setEnabled(Settings::downloadNetwork() == 1);
+    lbluserDefinedLocation->setEnabled(Settings::downloadNetwork() == 1);
     cbSaveWhazzupData->setChecked(Settings::saveWhazzupData());
 
     // screenshots

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -432,8 +432,8 @@ void PreferencesDialog::on_cbNetwork_currentIndexChanged(int index) {
         break;
     }
 
-    editUserDefinedLocation->setEnabled(index == 2);
-    lbluserDefinedLocation->setEnabled(index == 2);
+    editUserDefinedLocation->setEnabled(index == 1);
+    lbluserDefinedLocation->setEnabled(index == 1);
 }
 
 void PreferencesDialog::on_editUserDefinedLocation_editingFinished() {

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -63,11 +63,6 @@
                </property>
                <item>
                 <property name="text">
-                 <string>IVAO</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
                  <string>VATSIM</string>
                 </property>
                </item>

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -70,15 +70,30 @@ GLuint Sector::glBorderLine() {
 }
 
 QPair<double, double> Sector::getCenter() {
+    // https://en.wikipedia.org/wiki/Centroid#Of_a_polygon
+
+    double A = 0;
     QPair<double, double> runningTotal;
     runningTotal.first = 0;
     runningTotal.second = 0;
-    foreach(const DoublePair p, points) {
-        runningTotal.first += p.first;
-        runningTotal.second += p.second;
+    const int count = points.size();
+    for(int i = 0; i < points.size(); ++i) {
+        A += (points[i].first * points[(i + 1) % count].second
+             - points[(i + 1) % count].first * points[i].second);
+
+        double multiplyBy = points[i].first * points[(i + 1) % count].second
+                            - (points[(i + 1) % count].first * points[i].second);
+
+        runningTotal.first += (points[i].first + points[(i + 1) % count].first)
+                            * multiplyBy;
+        
+        runningTotal.second += (points[i].second + points[(i + 1) % count].second)
+                            * multiplyBy;
     }
-    runningTotal.first /= points.size();
-    runningTotal.second /= points.size();
+    A /= 2;
+
+    runningTotal.first /= 6 * A;
+    runningTotal.second /= 6 * A;
 
     return runningTotal;
 }

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -68,3 +68,17 @@ GLuint Sector::glBorderLine() {
     }
     return _borderline;
 }
+
+QPair<double, double> Sector::getCenter() {
+    QPair<double, double> runningTotal;
+    runningTotal.first = 0;
+    runningTotal.second = 0;
+    foreach(const DoublePair p, points) {
+        runningTotal.first += p.first;
+        runningTotal.second += p.second;
+    }
+    runningTotal.first /= points.size();
+    runningTotal.second /= points.size();
+
+    return runningTotal;
+}

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -69,7 +69,7 @@ GLuint Sector::glBorderLine() {
     return _borderline;
 }
 
-QPair<double, double> Sector::getCenter() {
+QPair<double, double> Sector::getCenter() const {
     // https://en.wikipedia.org/wiki/Centroid#Of_a_polygon
 
     double A = 0;

--- a/src/Sector.h
+++ b/src/Sector.h
@@ -27,7 +27,7 @@ class Sector {
         GLuint glPolygon();
         GLuint glBorderLine();
 
-        QPair<double, double> getCenter();
+        QPair<double, double> getCenter() const;
     private:
         GLuint _polygon, _borderline;
 };

--- a/src/Sector.h
+++ b/src/Sector.h
@@ -26,6 +26,8 @@ class Sector {
 
         GLuint glPolygon();
         GLuint glBorderLine();
+
+        QPair<double, double> getCenter();
     private:
         GLuint _polygon, _borderline;
 };

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -318,9 +318,8 @@ void Settings::setDownloadNetwork(int i) {
 
 QString Settings::downloadNetworkName() {
     switch(downloadNetwork()) {
-    case 0: return "IVAO"; break;
-    case 1: return "VATSIM"; break;
-    case 2: return "User Network"; break;
+    case 0: return "VATSIM"; break;
+    case 1: return "User Network"; break;
     }
     return "Unknown";
 }

--- a/src/Whazzup.cpp
+++ b/src/Whazzup.cpp
@@ -90,7 +90,7 @@ void Whazzup::processStatus() {
 
         if(list.size() != 2) continue;
 
-        if("url0" == list[0])
+        if("json3" == list[0])
             _urls.append(list[1]);
         else if("gzurl0" == list[0])
             _gzurls.append(list[1]);

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -82,6 +82,15 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type):
                     friendsLatLon.append(QPair<double, double>(c->lat, c->lon));
             }
         }
+
+        if(json.contains("prefiles") && json["prefiles"].isArray()) {
+            QJsonArray prefilesArray = json["prefiles"].toArray();
+            for(int i = 0; i < prefilesArray.size(); ++i) {
+                QJsonObject prefileObject = prefilesArray[i].toObject();
+                Pilot *p = new Pilot(prefileObject, this);
+                bookedPilots[p->label] = p;
+            }
+        }
     } else {
         // Try again in 15 seconds
         updateEarliest = QDateTime::currentDateTime().addSecs(15);

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -169,7 +169,7 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data):
         updateEarliest(QDateTime()), whazzupTime(QDateTime()),
         bookingsTime(QDateTime()), predictionBasedOnTime(QDateTime()),
         predictionBasedOnBookingsTime(QDateTime()), _whazzupVersion(0) {
-    /*qApp->setOverrideCursor(QCursor(Qt::WaitCursor));
+    qApp->setOverrideCursor(QCursor(Qt::WaitCursor));
     qDebug() << "WhazzupData::WhazzupData(predictTime)" << predictTime;
 
     _whazzupVersion = data._whazzupVersion;
@@ -182,34 +182,27 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data):
     foreach(const BookedController* bc, data.bookedControllers) {
         //if (bc == 0) continue;
         if (bc->starts() <= predictTime && bc->ends() >= predictTime) { // only ones booked for the selected time
-            QStringList sl;
-            for(int h=0; h < 40; h++)
-                sl.append(QString()); // build a QStringList with enough items
+            QJsonObject controllerObject;
 
-            //userId = getField(stringList, 1);
-            sl[0]= bc->label;
-            sl[2] = bc->realName;
-            sl[18] = QString("%1").arg(bc->facilityType);
-
-            //lat = getField(stringList, 5).toDouble();
-            //lon = getField(stringList, 6).toDouble();
-            sl[5] = QString("%1").arg(bc->lat);
-            sl[6] = QString("%1").arg(bc->lon);
+            controllerObject["callsign"] = bc->label;
+            controllerObject["name"] = bc->realName;
+            controllerObject["facility"] = bc->facilityType;
 
             //atisMessage = getField(stringList, 35);
-            sl[35] = QString::fromUtf8("^§BOOKED from %1, online until %2^§%3") // dont't change this String, it is needed for correctly assigning onlineUntil
-                    .arg(bc->starts().toString("HHmm'z'"))
-                    .arg(bc->ends().toString("HHmm'z'"))
-                    .arg(bc->bookingInfoStr);
+            QJsonArray atisLines;
+            atisLines.append(QString("BOOKED from %1, online until %2").arg(bc->starts().toString("HHmm'z'")
+                                                                .arg(bc->ends().toString("HHmm'z'"))));
+            atisLines.append(bc->bookingInfoStr);
+            controllerObject["text_atis"] = atisLines;
 
             //timeConnected = QDateTime::fromString(getField(stringList, 37), "yyyyMMddHHmmss");
-            sl[37] = bc->timeConnected.toString("yyyyMMddHHmmss");
+            controllerObject["logon_time"] = bc->timeConnected.toString(Qt::ISODate);
 
             //server = getField(stringList, 14);
-            sl[14] = "BOOKED SESSION";
+            controllerObject["server"] = "BOOKED SESSION";
 
             //visualRange = getField(stringList, 19).toInt();
-            sl[19] = QString("%1").arg(bc->visualRange);
+            controllerObject["visual_range"] = bc->visualRange;
 
             // not applicable:
             //frequency = getField(stringList, 4);
@@ -218,7 +211,7 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data):
             //protrevision = getField(stringList, 15).toInt();
             //rating = getField(stringList, 16).toInt();
 
-            controllers[bc->label] = new Controller(sl, this);
+            controllers[bc->label] = new Controller(controllerObject, this);
         }
     }
 
@@ -305,7 +298,7 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data):
         pilots[np->label] = np;
     }
     qApp->restoreOverrideCursor();
-    qDebug() << "WhazzupData::WhazzupData(predictTime) -- finished";*/
+    qDebug() << "WhazzupData::WhazzupData(predictTime) -- finished";
 }
 
 WhazzupData::WhazzupData(const WhazzupData &data) {

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -30,7 +30,7 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type):
     QStringList friends = Settings::friends();
     int reloadInMin = Settings::downloadInterval();
     QJsonDocument data = QJsonDocument::fromJson(*bytes);
-    if(!data.isNull()) {
+    if(!data.isNull() && type == WHAZZUP) {
         QJsonObject json = data.object();
         if(json.contains("general") && json["general"].isObject()) {
             QJsonObject generalObject = json["general"].toObject();
@@ -89,6 +89,67 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type):
                 QJsonObject prefileObject = prefilesArray[i].toObject();
                 Pilot *p = new Pilot(prefileObject, this);
                 bookedPilots[p->label] = p;
+            }
+        }
+    } else if(type == ATCBOOKINGS) {
+        // ATC Bookings are still in the old format, however we only need the CLIENTS and GENERAL sections
+        enum ParserState {STATE_NONE, STATE_GENERAL, STATE_CLIENTS};
+        ParserState state = STATE_NONE;
+        foreach(QString line, bytes->split('\n')) {
+            line = line.trimmed();
+            if(line.isEmpty())
+                continue;
+            
+            if(line.startsWith(';'))
+                continue;
+            
+            if(line.startsWith("!")) {
+                if(line.startsWith("!CLIENTS"))
+                    state = STATE_CLIENTS;
+                else if(line.startsWith("!GENERAL"))
+                    state = STATE_GENERAL;
+                else
+                    state = STATE_NONE;
+                
+                continue;
+            }
+            
+            switch(state) {
+                case STATE_CLIENTS: {
+                    QStringList list = line.split(':');
+
+                    if(list.size() < 38)
+                        continue;
+
+                    if(list[3] != "ATC")
+                        continue;
+                    // Create a JSON Object containing the required fields
+                    QJsonObject controllerObject;
+                    controllerObject["callsign"] = list[0];
+                    controllerObject["cid"] = list[1].toInt();
+                    controllerObject["name"] = list[2];
+
+                    // Bookings only:
+                    controllerObject["bookingType"] = list[4].toInt();
+                    controllerObject["timeTo"] = list[14];
+                    controllerObject["date"] = list[16];
+                    controllerObject["link"] = list[35];
+                    controllerObject["timeFrom"] = list[37];
+
+                    BookedController *bc = new BookedController(controllerObject, this);
+                    bookedControllers.append(bc);
+                }
+                    break;
+                case STATE_GENERAL: {
+                    QStringList list = line.split("=");
+                    if(list.size() != 2)
+                        continue;
+                    if(line.startsWith("UPDATE")) {
+                        bookingsTime = QDateTime::fromString(list[1].trimmed(), "yyyyMMddHHmmss");
+                        bookingsTime.setTimeSpec(Qt::UTC);
+                    }
+                }
+                    break;
             }
         }
     } else {

--- a/src/WhazzupData.h
+++ b/src/WhazzupData.h
@@ -48,8 +48,7 @@ class WhazzupData {
 
         QDateTime updateEarliest, whazzupTime, bookingsTime, predictionBasedOnTime, predictionBasedOnBookingsTime;
 
-        bool isIvao() const { return _whazzupVersion == 6; }
-        bool isVatsim() const { return (_whazzupVersion == 8 || _whazzupVersion == 9); }
+        bool isVatsim() const { return true; }
 
         void accept(MapObjectVisitor *visitor) const;
     private:


### PR DESCRIPTION
This is not yet ready to be merged, but I wanted to open a PR to prevent someone else from unnecessarily doing the same work.

Edit: Here's an overview of what's done and what still needs to be done:
- [X] Load "json3" instead of "url0" data
- [X] Adjust Client
- [X] Adjust Pilot
- [X] Adjust Controller
- [X] Prefiles
- [x] Adjust BookedController
- [x] Adjust simulating controllers
- [x] Replacement for lat/lon in the Data for Controllers
- [x] Remove options for IVAO