### PR TITLE
Fix ATIS with the new data format

### DIFF
--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -83,6 +83,15 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type):
             }
         }
 
+        if(json.contains("atis") && json["atis"].isArray()) {
+            QJsonArray atisArray = json["atis"].toArray();
+            for(int i = 0; i < atisArray.size(); ++i) {
+                QJsonObject atisObject = atisArray[i].toObject();
+                Controller *c = new Controller(atisObject, this);
+                controllers[c->label] = c;
+            }
+        }
+
         if(json.contains("prefiles") && json["prefiles"].isArray()) {
             QJsonArray prefilesArray = json["prefiles"].toArray();
             for(int i = 0; i < prefilesArray.size(); ++i) {


### PR DESCRIPTION
The new data format splits up controllers and ATIS.
For some reason I totally missed that when changing QuteScoop to the new format, so QuteScoop doesn't display ATIS anymore, this fixes this.