### PR TITLE
[FEATURE] add chartfox and more controls to airport dialog

### DIFF
--- a/src/AirportDetails.cpp
+++ b/src/AirportDetails.cpp
@@ -103,11 +103,7 @@ void AirportDetails::refresh(Airport* newAirport) {
     lblName->setText(QString("%1\n%2").arg(_airport->city, _airport->name));
     lblCountry->setText(QString("%1 (%2)")
                         .arg(_airport->countryCode, NavData::instance()->countryCodes[_airport->countryCode]));
-    lblLocation->setText(QString("%1%2 %3%4").
-                         arg(_airport->lat > 0? "N": "S").
-                         arg(qAbs(_airport->lat), 6, 'f', 3, '0').
-                         arg(_airport->lon > 0? "E": "W").
-                         arg(qAbs(_airport->lon), 7, 'f', 3, '0'));
+    lblCharts->setText(QString("[chartfox.org/%1](https://chartfox.org/%1)").arg(_airport->label));
 
     int utcDev = (int) (_airport->lon / 180. * 12. + .5); // lets estimate the deviation from UTC and round that
     QString lt = Whazzup::instance()->whazzupData().whazzupTime.
@@ -144,18 +140,17 @@ void AirportDetails::refresh(Airport* newAirport) {
     groupBoxAtc->setTitle(QString("ATC (%1)").arg(atcContent.size()));
 
     // ATIS
-    if(cbAtis->isChecked()) {
-        Controller* atis = Whazzup::instance()->whazzupData().controllers[_airport->label + "_ATIS"];
-        if (atis != 0)
-            atcContent.insert(atis);
+    Controller* atis = Whazzup::instance()->whazzupData().controllers[_airport->label + "_ATIS"];
+    if (atis != 0) {
+        atcContent.insert(atis);
     }
 
     // non-ATC
-    if(cbObservers->isChecked()) {
+    if(cbOtherAtc->isChecked()) {
         foreach(Controller *c, Whazzup::instance()->whazzupData().controllers) {
-            //if(c->isObserver()) // don't need this anymore - we want them all
-                if(NavData::distance(_airport->lat, _airport->lon, c->lat, c->lon) < qMax(50, c->visualRange))
-                    atcContent.insert(c);
+            // add those within visual range or max. 50 NM away
+            if(NavData::distance(_airport->lat, _airport->lon, c->lat, c->lon) < qMax(50, c->visualRange))
+                atcContent.insert(c);
         }
     }
 
@@ -188,14 +183,6 @@ void AirportDetails::on_cbPlotRoutes_toggled(bool checked) {
         if (PilotDetails::instance(false) != 0)
             PilotDetails::instance()->refresh();
     }
-}
-
-void AirportDetails::on_cbObservers_toggled(bool) {
-    refresh();
-}
-
-void AirportDetails::on_cbAtis_toggled(bool) {
-    refresh();
 }
 
 void AirportDetails::on_pbMetar_clicked() {
@@ -274,3 +261,9 @@ void AirportDetails::closeEvent(QCloseEvent *event) {
    Settings::setAirportDetailsGeometry(saveGeometry());
    event->accept();
 }
+
+void AirportDetails::on_cbOtherAtc_toggled(bool)
+{
+    refresh();
+}
+

--- a/src/AirportDetails.h
+++ b/src/AirportDetails.h
@@ -32,14 +32,13 @@ class AirportDetails : public ClientDetails, private Ui::AirportDetails {
     private slots:
         void onGotMetar(const QString &airportLabel, const QString &encoded, const QString &humanHtml);
         void on_pbMetar_clicked();
-        void on_cbAtis_toggled(bool checked);
-        void on_cbObservers_toggled(bool checked);
         void on_cbPlotRoutes_toggled(bool checked);
+        void on_cbOtherAtc_toggled(bool checked);
         void atcSelected(const QModelIndex &index);
         void arrivalSelected(const QModelIndex &index);
         void departureSelected(const QModelIndex &index);
 
-    private:
+private:
         AirportDetails(QWidget *parent);
 
         AirportDetailsAtcModel _atcModel;

--- a/src/AirportDetails.ui
+++ b/src/AirportDetails.ui
@@ -25,55 +25,13 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QGroupBox" name="groupBoxInfo">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <property name="title">
         <string>Airport information</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
-       <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="autoFillBackground">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>name</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="lblName">
-          <property name="font">
-           <font>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Innsbruck
-Kranebitten</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>country</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
+       <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
         <item row="1" column="1">
          <widget class="QLabel" name="lblCountry">
           <property name="font">
@@ -86,42 +44,7 @@ Kranebitten</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>location</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="1">
-         <widget class="QLabel" name="lblLocation">
-          <property name="font">
-           <font>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>N47.154' E009.372</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="toolTip">
-           <string>local time simply estimated by longitude</string>
-          </property>
-          <property name="text">
-           <string>time (est.)</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
          <widget class="QLabel" name="lblTime">
           <property name="font">
            <font>
@@ -136,7 +59,49 @@ Kranebitten</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="autoFillBackground">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>name</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLabel" name="lblMetar">
+          <property name="text">
+           <string>LOWI 062220Z 27016G28KT 240V350 9999 SHRA FEW008 BKN020TCU BKN030 05/03 Q1004</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QLabel" name="lblCharts">
+          <property name="text">
+           <string>[chartfox.org/EKCH](https://chartfox.org/EKCH)</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::MarkdownText</enum>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
          <widget class="QWidget" name="verticalWidgetMetar" native="true">
           <layout class="QVBoxLayout" name="verticalLayoutMetar">
            <property name="leftMargin">
@@ -188,34 +153,51 @@ Kranebitten</string>
           </layout>
          </widget>
         </item>
-        <item row="4" column="1">
-         <widget class="QLabel" name="lblMetar">
+        <item row="4" column="0">
+         <widget class="QLabel" name="_lblCharts">
           <property name="text">
-           <string>LOWI 062220Z 27016G28KT 240V350 9999 SHRA FEW008 BKN020TCU BKN030 05/03 Q1004</string>
+           <string>Charts</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="toolTip">
+           <string>local time simply estimated by longitude</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
+          <property name="text">
+           <string>time (est.)</string>
           </property>
-         </spacer>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>country</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="lblName">
+          <property name="font">
+           <font>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Innsbruck
+Kranebitten</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>
@@ -223,7 +205,7 @@ Kranebitten</string>
      <item>
       <widget class="QGroupBox" name="groupBoxAtc">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
          <horstretch>2</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -282,27 +264,13 @@ Kranebitten</string>
            </spacer>
           </item>
           <item>
-           <widget class="QCheckBox" name="cbAtis">
+           <widget class="QCheckBox" name="cbOtherAtc">
             <property name="toolTip">
-             <string>show ATISes in ATC list</string>
-            </property>
-            <property name="text">
-             <string>show
-&amp;ATIS</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbObservers">
-            <property name="toolTip">
-             <string>show observers in ATC list</string>
+             <string>show all ATC within range</string>
             </property>
             <property name="text">
              <string>show 
-&amp;non-
+&amp;other
 ATC</string>
             </property>
            </widget>

--- a/src/AirportDetails.ui
+++ b/src/AirportDetails.ui
@@ -20,10 +20,16 @@
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="_2">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
+    <widget class="QSplitter" name="splitter_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QSplitter" name="splitter">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
       <widget class="QGroupBox" name="groupBoxInfo">
        <property name="title">
         <string>Airport information</string>
@@ -31,7 +37,7 @@
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
-       <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
+       <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
         <item row="1" column="1">
          <widget class="QLabel" name="lblCountry">
           <property name="font">
@@ -44,31 +50,16 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <widget class="QLabel" name="lblTime">
-          <property name="font">
-           <font>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>local time simply estimated by longitude</string>
-          </property>
+        <item row="4" column="1">
+         <widget class="QLabel" name="lblCharts">
           <property name="text">
-           <string>09:13 loc, UTC +2</string>
+           <string>[chartfox.org/EKCH](https://chartfox.org/EKCH)</string>
           </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="autoFillBackground">
-           <bool>false</bool>
+          <property name="textFormat">
+           <enum>Qt::MarkdownText</enum>
           </property>
-          <property name="text">
-           <string>name</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <property name="openExternalLinks">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -88,16 +79,28 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
-         <widget class="QLabel" name="lblCharts">
+        <item row="2" column="1">
+         <widget class="QLabel" name="lblTime">
+          <property name="font">
+           <font>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>local time simply estimated by longitude</string>
+          </property>
           <property name="text">
-           <string>[chartfox.org/EKCH](https://chartfox.org/EKCH)</string>
+           <string>09:13 loc, UTC +2</string>
           </property>
-          <property name="textFormat">
-           <enum>Qt::MarkdownText</enum>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="_lblCharts">
+          <property name="text">
+           <string>Charts</string>
           </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
@@ -153,29 +156,6 @@
           </layout>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="_lblCharts">
-          <property name="text">
-           <string>Charts</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="toolTip">
-           <string>local time simply estimated by longitude</string>
-          </property>
-          <property name="text">
-           <string>time (est.)</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="0">
          <widget class="QLabel" name="label_5">
           <property name="text">
@@ -199,10 +179,47 @@ Kranebitten</string>
           </property>
          </widget>
         </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="autoFillBackground">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>name</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="toolTip">
+           <string>local time simply estimated by longitude</string>
+          </property>
+          <property name="text">
+           <string>time (est.)</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </widget>
-     </item>
-     <item>
       <widget class="QGroupBox" name="groupBoxAtc">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -279,99 +296,95 @@ ATC</string>
         </item>
        </layout>
       </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBoxArrivals">
-     <property name="toolTip">
-      <string>numbers reflect the Preferences/Display (airports)/traffic visualization settings</string>
-     </property>
-     <property name="title">
-      <string>Arrivals (10 filtered, 12 total)</string>
-     </property>
-     <layout class="QVBoxLayout">
-      <property name="margin" stdset="0">
-       <number>3</number>
+     </widget>
+     <widget class="QGroupBox" name="groupBoxArrivals">
+      <property name="toolTip">
+       <string>numbers reflect the Preferences/Display (airports)/traffic visualization settings</string>
       </property>
-      <item>
-       <widget class="QTreeView" name="treeArrivals">
-        <property name="editTriggers">
-         <set>QAbstractItemView::NoEditTriggers</set>
-        </property>
-        <property name="tabKeyNavigation">
-         <bool>true</bool>
-        </property>
-        <property name="showDropIndicator" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="rootIsDecorated">
-         <bool>false</bool>
-        </property>
-        <property name="uniformRowHeights">
-         <bool>true</bool>
-        </property>
-        <property name="itemsExpandable">
-         <bool>false</bool>
-        </property>
-        <property name="sortingEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="allColumnsShowFocus">
-         <bool>true</bool>
-        </property>
-        <property name="expandsOnDoubleClick">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBoxDepartures">
-     <property name="toolTip">
-      <string>numbers reflect the Preferences/Display (airports)/traffic visualization settings</string>
-     </property>
-     <property name="title">
-      <string>Departures (2 filtered, 8 total)</string>
-     </property>
-     <layout class="QVBoxLayout">
-      <property name="margin" stdset="0">
-       <number>3</number>
+      <property name="title">
+       <string>Arrivals (10 filtered, 12 total)</string>
       </property>
-      <item>
-       <widget class="QTreeView" name="treeDepartures">
-        <property name="editTriggers">
-         <set>QAbstractItemView::NoEditTriggers</set>
-        </property>
-        <property name="tabKeyNavigation">
-         <bool>true</bool>
-        </property>
-        <property name="showDropIndicator" stdset="0">
-         <bool>false</bool>
-        </property>
-        <property name="rootIsDecorated">
-         <bool>false</bool>
-        </property>
-        <property name="uniformRowHeights">
-         <bool>true</bool>
-        </property>
-        <property name="itemsExpandable">
-         <bool>false</bool>
-        </property>
-        <property name="sortingEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="allColumnsShowFocus">
-         <bool>true</bool>
-        </property>
-        <property name="expandsOnDoubleClick">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
+      <layout class="QVBoxLayout">
+       <property name="margin" stdset="0">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QTreeView" name="treeArrivals">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="tabKeyNavigation">
+          <bool>true</bool>
+         </property>
+         <property name="showDropIndicator" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+         <property name="itemsExpandable">
+          <bool>false</bool>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <property name="allColumnsShowFocus">
+          <bool>true</bool>
+         </property>
+         <property name="expandsOnDoubleClick">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QGroupBox" name="groupBoxDepartures">
+      <property name="toolTip">
+       <string>numbers reflect the Preferences/Display (airports)/traffic visualization settings</string>
+      </property>
+      <property name="title">
+       <string>Departures (2 filtered, 8 total)</string>
+      </property>
+      <layout class="QVBoxLayout">
+       <property name="margin" stdset="0">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QTreeView" name="treeDepartures">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="tabKeyNavigation">
+          <bool>true</bool>
+         </property>
+         <property name="showDropIndicator" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+         <property name="itemsExpandable">
+          <bool>false</bool>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <property name="allColumnsShowFocus">
+          <bool>true</bool>
+         </property>
+         <property name="expandsOnDoubleClick">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
[FEATURE] allow to control layout of airport dialog
This adds splitters between all shown panels. Those allow to adjust the size distribution or hide of the panels.


[FEATURE] add chartfox charts links to airport dialog 
Fixes #58 
    
Some drive-by changes:
Also fix ATC list layout in the airport dialog layout (was not vertically maximized).
Also renames "show observers" to "show other ATC".
Also removes "show ATIS" option (default is now "on").
Also removes lat/lon display of airport.
