### PR TITLE
Fix calculation of sector centers at the longitude wrap around

### DIFF
--- a/data/_notes.txt
+++ b/data/_notes.txt
@@ -52,10 +52,10 @@ LRBB      - FIR code, usually an ICAO code but you can also use non-ICAO
             codes, or add middle letter(s) to them (e.g. LRBB_N)
 Bucharest - name of the sector
 RO        - [UNUSED] ISO code of the country where this airspace is
-45.3      - position of the label - decimal latitude (north is positive,
-            south is negative)
-25.6      - position of the label - decimal longitude (east is positive,
-            west is negative)
+45.3 [unused] - position of the label - decimal latitude (north is positive,
+            south is negative) [deprecated, not used in QuteScoop any more]
+25.6 [unused] - position of the label - decimal longitude (east is positive,
+            west is negative) [deprecated, not used in QuteScoop any more]
 186       - Display List ID, a number that uniquely identifies the shape
             in firdisplay.dat that is displayed when this sector is active
 

--- a/src/BookedController.cpp
+++ b/src/BookedController.cpp
@@ -68,16 +68,18 @@ BookedController::BookedController(const QJsonObject& json, const WhazzupData* w
         facilityType = 6;
         QString ctr = this->getCenter();
         if (NavData::instance()->sectors.contains(ctr)) {
-            lat = NavData::instance()->sectors[ctr]->lat;
-            lon = NavData::instance()->sectors[ctr]->lon;
+            QPair<double, double> sectorCenter = NavData::instance()->sectors[ctr]->getCenter();
+            lat = sectorCenter.first;
+            lon = sectorCenter.second;
             visualRange = 150;
         }
     } else if (label.right(4) == "_FSS") {
         facilityType = 7;
         QString ctr = this->getCenter();
         if (NavData::instance()->sectors.contains(ctr)) {
-            lat = NavData::instance()->sectors[ctr]->lat;
-            lon = NavData::instance()->sectors[ctr]->lon;
+            QPair<double, double> sectorCenter = NavData::instance()->sectors[ctr]->getCenter();
+            lat = sectorCenter.first;
+            lon = sectorCenter.second;
             visualRange = 500;
         }
     }
@@ -115,8 +117,9 @@ QString BookedController::getCenter() {
         list.removeLast();
         QString result = list.join("_");
         if(NavData::instance()->sectors.contains(result)) {
-            lat = NavData::instance()->sectors[result]->lat; // fix my coordinates
-            lon = NavData::instance()->sectors[result]->lon;
+            QPair<double, double> sectorCenter = NavData::instance()->sectors[result]->getCenter();
+            lat = sectorCenter.first;
+            lon = sectorCenter.second;
         }
         return result;
     }

--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -1269,9 +1269,13 @@ void GLWidget::renderLabels() {
                  Settings::firFontColor());
     if(_allSectorsDisplayed) {
         qglColor(Settings::firFontColor());
-        foreach (const Sector *sector, NavData::instance()->sectors)
-            renderText(SX(sector->lat, sector->lon), SY(sector->lat, sector->lon),
-                       SZ(sector->lat, sector->lon), sector->icao, Settings::firFont());
+        foreach (const Sector *sector, NavData::instance()->sectors) {
+            QPair<double, double> center = sector->getCenter();
+            double lat = center.first;
+            double lon = center.second;
+            renderText(SX(lat, lon), SY(lat, lon),
+                       SZ(lat, lon), sector->icao, Settings::firFont());
+        }
     }
 
     // planned route waypoint labels from Flightplan Dialog

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -90,8 +90,9 @@ QPair<double, double> Sector::getCenter() const {
     const int count = points.size();
 
     if(count == 0) {
-        qDebug() << "Sector::getCenter() Sector " << name << "(" << icao << ") doesn't contain any points";
-        return runningTotal;
+        qCritical() << "Sector::getCenter() Sector " << name << "(" << icao << ") doesn't contain any points";
+        QTextStream(stdout) << "CRITICAL: Sector " << name << "(" << icao << ") doesn't contain any points";
+        exit(EXIT_FAILURE);
     }
 
     QPair<double, double> previous = points[0];

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -77,6 +77,10 @@ QPair<double, double> Sector::getCenter() const {
     runningTotal.second = 0;
     const int count = points.size();
     QList<QPair<double, double>> pointsNorm;
+    if(count == 0) {
+        qDebug() << "Sector::getCenter() Sector " << name << "(" << icao << ") doesn't contain any points";
+        return runningTotal;
+    }
     pointsNorm.append(points[0]);
     for(int i = 1; i < count; ++i) {
         QPair<double, double> pointNorm = points[i];

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -13,8 +13,6 @@ Sector::Sector(QStringList strings) {
     //LSAZ:Zurich:CH:46.9:9.1:189
     icao = strings[0];
     name = strings[1];
-    lat = strings[3].toDouble();
-    lon = strings[4].toDouble();
     id = strings[5];
 
     _polygon = 0;

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -76,23 +76,37 @@ QPair<double, double> Sector::getCenter() const {
     runningTotal.first = 0;
     runningTotal.second = 0;
     const int count = points.size();
-    for(int i = 0; i < points.size(); ++i) {
-        A += (points[i].first * points[(i + 1) % count].second
-             - points[(i + 1) % count].first * points[i].second);
+    QList<QPair<double, double>> pointsNorm;
+    pointsNorm.append(points[0]);
+    for(int i = 1; i < count; ++i) {
+        QPair<double, double> pointNorm = points[i];
+        const double diff = pointsNorm[i - 1].second - pointNorm.second;
+        // Check wether we need to shift this point
+        if(std::abs(diff) > 180) {
+            pointNorm.second = pointNorm.second + ((diff > 0) - (diff < 0)) * 360;
+        }
+        pointsNorm.append(pointNorm);
+    }
 
-        double multiplyBy = points[i].first * points[(i + 1) % count].second
-                            - (points[(i + 1) % count].first * points[i].second);
+    for(int i = 0; i < count; ++i) {
+        A += (pointsNorm[i].first * pointsNorm[(i + 1) % count].second
+             - pointsNorm[(i + 1) % count].first * pointsNorm[i].second);
 
-        runningTotal.first += (points[i].first + points[(i + 1) % count].first)
+        double multiplyBy = pointsNorm[i].first * pointsNorm[(i + 1) % count].second
+                            - (pointsNorm[(i + 1) % count].first * pointsNorm[i].second);
+
+        runningTotal.first += (pointsNorm[i].first + pointsNorm[(i + 1) % count].first)
                             * multiplyBy;
         
-        runningTotal.second += (points[i].second + points[(i + 1) % count].second)
+        runningTotal.second += (pointsNorm[i].second + pointsNorm[(i + 1) % count].second)
                             * multiplyBy;
     }
     A /= 2;
 
     runningTotal.first /= 6 * A;
     runningTotal.second /= 6 * A;
+
+    runningTotal.second = std::fmod(runningTotal.second + 180, 360) - 180;
 
     return runningTotal;
 }

--- a/src/Sector.h
+++ b/src/Sector.h
@@ -11,7 +11,7 @@
 class Sector {
     public:
         Sector() :
-            icao(), name(), id(), lat(0.), lon(0.), _polygon(0), _borderline(0)
+            icao(), name(), id(), _polygon(0), _borderline(0)
         {}
         Sector(QStringList strings);
         ~Sector();
@@ -22,7 +22,6 @@ class Sector {
 
         QList<QPair<double, double> > points;
         QString icao, name, id;
-        double lat, lon;
 
         GLuint glPolygon();
         GLuint glBorderLine();


### PR DESCRIPTION
See #52 
I'd like to get some feedback on whether this introduces any weirdness.
Builds: [Linux](https://github.com/Luca0208/qutescoop/actions/runs/1836514801), [Mac](https://github.com/Luca0208/qutescoop/actions/runs/1836514803), [Windows](https://github.com/Luca0208/qutescoop/actions/runs/1836514895)