### PR TITLE
[TASK] cleanup Debug Log browser occurences

### DIFF
--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -101,8 +101,7 @@ void PreferencesDialog::loadSettings() {
             << Settings::dataDirectory("textures/+notes.txt")
             << "for more information.";
     glTextureEarth->setToolTip(
-            QString("Shows all textures from\n%1\n in the supported formats"
-                    "(View/Debug log shows them).\n"
+            QString("Shows all textures from\n%1\n in the supported formats\n"
                     "See +notes.txt in the texture directory for more information.").
             arg(Settings::dataDirectory("textures")));
     glTextureEarth->addItems(texDir.entryList()); // first without icons, use lazy-load

--- a/textures/_notes.txt
+++ b/textures/_notes.txt
@@ -1,8 +1,9 @@
 Textures:
 You can add textures here in all supported formats that get reported in 
-View/Debug log (same as the contents of log.txt) when opening Preferences.
+log.txt.
 Depending on your graphics card, it might be necessary that width and height 
 are a power of 2 (1024, 2048, 4096...) pixels.
 The Preferences Dialog will let you choose between all available textures.
 
-The debug log will tell you if there was an error loading the texture. 
+log.txt will contain the error if there has been one while loading the 
+texture. 


### PR DESCRIPTION
We removed the in-app debug log browser some time ago.
This cleans up some remaining mentions of it.