### PR TITLE
Update map when changing friends status // use checkbox for "hightlight friends"

### DIFF
--- a/src/ClientDetails.cpp
+++ b/src/ClientDetails.cpp
@@ -33,11 +33,14 @@ void ClientDetails::showOnMap() const {
 
 void ClientDetails::friendClicked() const {
     if(!userId.isEmpty()) {
-        if(Settings::friends().contains(userId)) // was friend, remove
+        if(Settings::friends().contains(userId))
             Settings::removeFriend(userId);
-        else // new friend
+        else
             Settings::addFriend(userId);
-        if (Window::instance(false) != 0)
+
+        if (Window::instance(false) != 0) {
             Window::instance()->refreshFriends();
+            Window::instance()->mapScreen->glWidget->newWhazzupData(true);
+        }
     }
 }

--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -1674,7 +1674,7 @@ void GLWidget::newWhazzupData(bool isNew) {
         createPilotsList();
         createAirportsList();
         createControllersLists();
-        _friends = Whazzup::instance()->whazzupData().friendsLatLon;
+        _friends = Whazzup::instance()->whazzupData().friendsLatLon();
 
         updateGL();
     }

--- a/src/WhazzupData.h
+++ b/src/WhazzupData.h
@@ -35,7 +35,7 @@ class WhazzupData {
         QList<Pilot*> allPilots() const { return bookedPilots.values() + pilots.values(); }
         QList<BookedController*> bookedControllers;
 
-        QList<QPair<double, double> > friendsLatLon;
+        QList<QPair<double, double> > friendsLatLon() const;
 
         Pilot* findPilot(const QString& callsign) const {
             Pilot* pilot = pilots.value(callsign);

--- a/src/Window.ui
+++ b/src/Window.ui
@@ -671,18 +671,12 @@ Whazzups (replay)</string>
         </spacer>
        </item>
        <item>
-        <widget class="QPushButton" name="pb_highlightFriends">
+        <widget class="QCheckBox" name="pb_highlightFriends">
          <property name="toolTip">
           <string>draws a circle around friends on the map</string>
          </property>
          <property name="text">
           <string>highlight</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
[BUGFIX] show added friends immediately on the map
    
Fixes #82

This removes the previously cached list of friends in `WhazzupData` and replaces it with a function.
It is only called when updating the `WhazzupData` so there is no performance penalty but just less necessary house-keeping of the cache.


Drive-by change:
[TASK] use checkbox for "highlight friends"
