### PR TITLE
[BUGFIX] strip DIST-win64/ root dir from Windows builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -156,9 +156,10 @@ jobs:
           name: "Debug: Win-${{ needs.facts.outputs.version }}-Makefile"
           path: ./Makefile*
       - name: zip
+        working-directory: DIST-win64
         run: |
           mkdir ~/release
-          Compress-Archive DIST-win64 ~/release/QuteScoop-${{ needs.facts.outputs.version }}-win.zip
+          Compress-Archive -Path * -DestinationPath ~/release/QuteScoop-${{ needs.facts.outputs.version }}-win.zip
       - name: Upload
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Fixes #73

Reference:
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.archive/compress-archive?view=powershell-7.2#example-4--compress-a-directory-that-excludes-the-root-directory