### PR TITLE
[TASK] shorten artifact names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
-          name: QuteScoop-${{ needs.facts.outputs.version }}-linux
+          name: QuteScoop-linux
           path: ~/release/*
 
   build-win:
@@ -162,7 +162,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
-          name: QuteScoop-${{ needs.facts.outputs.version }}-win
+          name: QuteScoop-win
           path: ~/release/*
 
   build-mac:
@@ -199,7 +199,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
-          name: QuteScoop-${{ needs.facts.outputs.version }}-macos
+          name: QuteScoop-macos
           path: ~/release/*
 
   release:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: "Debug: Linux-${{ needs.facts.outputs.version }}-Makefile"
+          name: "Debug_Linux-Makefile"
           path: ./Makefile*
       - name: Upload
         uses: actions/upload-artifact@v2
@@ -153,7 +153,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: "Debug: Win-${{ needs.facts.outputs.version }}-Makefile"
+          name: "Debug_Win-Makefile"
           path: ./Makefile*
       - name: zip
         run: |
@@ -189,7 +189,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: "Debug: macos-${{ needs.facts.outputs.version }}-Makefile"
+          name: "Debug_macos-${{ needs.facts.outputs.version }}-Makefile"
           path: ./Makefile*
       - name: zip
         run: |


### PR DESCRIPTION
  [TASK] shorten artifact names
    
    When accessing artifacts from the build page, the long artifacts names
    lead to Github UI problems.
    
    This does not affect the release "asset" names.


Drive-by change:

  [BUGFIX] Fix artifact name for failed builds


Relates #56 
