### PR TITLE
[BUGFIX] work-around a layout problem with date time fields on Windows

### DIFF
--- a/src/BookedAtcDialog.ui
+++ b/src/BookedAtcDialog.ui
@@ -34,7 +34,6 @@
       <widget class="QLabel" name="label">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -120,6 +119,11 @@
      </item>
      <item row="0" column="4">
       <widget class="QDateTimeEdit" name="dateTimeFilter">
+       <property name="styleSheet">
+        <string notr="true">* {
+  padding-right: 5px;
+}</string>
+       </property>
        <property name="wrapping">
         <bool>true</bool>
        </property>

--- a/src/Window.ui
+++ b/src/Window.ui
@@ -115,6 +115,11 @@ Whazzups (replay)</string>
          </item>
          <item>
           <widget class="QDateTimeEdit" name="dateTimePredict">
+           <property name="styleSheet">
+            <string notr="true">* {
+  padding-right: 5px;
+}</string>
+           </property>
            <property name="wrapping">
             <bool>true</bool>
            </property>


### PR DESCRIPTION
Somehow Qt on Windows miscalculates the necessary width for these
fields.

We are working around the problem by adding a little custom padding.

Fixes #55


Downloadable assets will appear under "Checks". It would be nice if you could test it @diibify 