### PR TITLE
[FEATURE] allow adding name aliases for friends

### DIFF
--- a/src/AirportDetailsAtcModel.cpp
+++ b/src/AirportDetailsAtcModel.cpp
@@ -50,7 +50,7 @@ QVariant AirportDetailsAtcModel::data(const QModelIndex &index, int role) const 
         case 0: return c->label; break;
         case 1: return c->frequency.toDouble() > 199 ? QVariant(): c->frequency; break; //sort out observers without prim freq
         case 2: return c->facilityString(); break;
-        case 3: return c->realName; break;
+        case 3: return c->realName(); break;
         case 4: return c->rank(); break;
         case 5: return c->onlineTime(); break;
         case 6: return c->assumeOnlineUntil.time().toString("HHmm'z'"); break;

--- a/src/BookedAtcDialogModel.cpp
+++ b/src/BookedAtcDialogModel.cpp
@@ -44,7 +44,7 @@ QVariant BookedAtcDialogModel::data(const QModelIndex &index, int role) const {
         switch(index.column()) {
             case 0: return c->label;
             case 1: return c->facilityString();
-            case 2: return c->realName;
+            case 2: return c->realName();
             case 3: return c->starts().toString("MM/dd (ddd)");
             case 4: return c->starts().time().toString("HHmm'z'");
             case 5: return c->ends().time().toString("HHmm'z'");

--- a/src/BookedController.cpp
+++ b/src/BookedController.cpp
@@ -207,7 +207,7 @@ QString BookedController::toolTip() const {
     result += " (";
     if(!isObserver() && !frequency.isEmpty())
         result += frequency + ", ";
-    result += realName;
+    result += realName();
     if(!rank().isEmpty())
         result += ", " + rank();
     result += ")";

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -7,26 +7,26 @@
 #include "Whazzup.h"
 #include "Settings.h"
 
-
 Client::Client(const QJsonObject& json, const WhazzupData*) {
     label = json["callsign"].toString();
     userId = QString::number(json["cid"].toInt());
-    realName = json["name"].toString();
+    m_name = json["name"].toString();
     lat = json["latitude"].toDouble();
     lon = json["longitude"].toDouble();
     server = json["server"].toString();
     rating = json["rating"].toInt();
     timeConnected = QDateTime::fromString(json["logon_time"].toString(), Qt::ISODate);
 
-    if(realName.contains(QRegExp("\\b[A-Z]{4}$"))) {
-        homeBase = realName.right(4);
-        realName = realName.left(realName.length() - 4).trimmed();
+    if(m_name.contains(QRegExp("\\b[A-Z]{4}$"))) {
+        homeBase = m_name.right(4);
+        m_name = m_name.left(m_name.length() - 4).trimmed();
     }
 }
 
 QString Client::onlineTime() const {
     if (!timeConnected.isValid())
         return QString("not connected");
+
     return QDateTime::fromTime_t( // this will get wrapped by 24h but that should not be a problem...
             Whazzup::instance()->whazzupData().whazzupTime.toTime_t()
             - timeConnected.toTime_t()
@@ -34,7 +34,8 @@ QString Client::onlineTime() const {
 }
 
 QString Client::displayName(bool withLink) const {
-    QString result = realName;
+    QString result = realName();
+
     if(!rank().isEmpty())
         result += " (" + rank() + ")";
 
@@ -48,10 +49,6 @@ QString Client::displayName(bool withLink) const {
     return result;
 }
 
-QString Client::clientInformation() const {
-    return QString();
-}
-
 QString Client::detailInformation() const {
     if(!homeBase.isEmpty()) {
         return "(" + homeBase + ")";
@@ -59,21 +56,53 @@ QString Client::detailInformation() const {
     return QString();
 }
 
+bool Client::showAliasDialog(QWidget *parent) const
+{
+    bool ok;
+    QString alias = QInputDialog::getText(
+        parent,
+        QString("Add alias"),
+        QString("Set an alias for %1 [empty to unset]:").arg(name()),
+        QLineEdit::Normal,
+        Settings::clientAlias(userId),
+        &ok
+    );
+    if (ok) {
+        Settings::setClientAlias(userId, alias);
+    }
+    return ok;
+}
+
 bool Client::matches(const QRegExp& regex) const {
-    if(realName.contains(regex)) return true;
+    if(m_name.contains(regex)) return true;
     if(userId.contains(regex)) return true;
     return MapObject::matches(regex);
 }
 
 QString Client::toolTip() const {
-    QString result = label + " (" + realName;
+    QString result = label + " (" + realName();
+
     if(!rank().isEmpty()) {
         result += ", " + rank();
     }
+
     result += ")";
     return result;
 }
 
 bool Client::isFriend() const {
     return Settings::friends().contains(userId);
+}
+
+const QString Client::realName() const {
+     auto& _alias = Settings::clientAlias(userId);
+     if (!_alias.isEmpty()) {
+         return _alias + " | " + m_name;
+     }
+     return m_name;
+}
+
+const QString Client::name() const
+{
+    return m_name;
 }

--- a/src/Client.h
+++ b/src/Client.h
@@ -22,17 +22,23 @@ class Client: public MapObject {
         virtual QString rank() const { return QString(); }
         virtual bool matches(const QRegExp& regex) const;
         bool isFriend() const;
+        const QString realName() const;
+        const QString name() const;
 
         // convenience functions for detail displays
         QString onlineTime() const;
         virtual QString displayName(bool withLink = false) const;
         virtual QString detailInformation() const;
-        QString clientInformation() const;
 
-        QString userId, realName, homeBase, server;
+        QString userId, homeBase, server;
         QDateTime timeConnected;
 
+        bool showAliasDialog(QWidget *parent) const;
+
         int adminRating, rating;
+
+    protected:
+        QString m_name;
 };
 
 #endif /*CLIENT_H_*/

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -210,7 +210,7 @@ QString Controller::toolTip() const { // LOVV_CTR [Vienna] (134.350, Name, C1)
     result += " (";
     if(!isObserver() && !frequency.isEmpty())
         result += frequency + ", ";
-    result += realName;
+    result += realName();
     if(!rank().isEmpty())
         result += ", " + rank();
     result += ")";
@@ -226,7 +226,7 @@ QString Controller::mapLabel() const { // LOVV
 bool Controller::matches(const QRegExp& regex) const {
     if (frequency.contains(regex)) return true;
     if (atisMessage.contains(regex)) return true;
-    if(realName.contains(regex)) return true;
+    if(realName().contains(regex)) return true;
     if (sector != 0)
         if (sector->name.contains(regex)) return true;
     return MapObject::matches(regex);

--- a/src/ControllerDetails.cpp
+++ b/src/ControllerDetails.cpp
@@ -56,18 +56,15 @@ void ControllerDetails::refresh(Controller *newController) {
     if(!details.isEmpty())
         controllerInfo += details + "<br>";
 
-    controllerInfo += QString("on %3 for %4")
-                      .arg(_controller->server)
-                      .arg(_controller->onlineTime());
-    if(!_controller->clientInformation().isEmpty())
-        controllerInfo += ", " + _controller->clientInformation();
     lblControllerInfo->setText(controllerInfo);
+
+    lblOnline->setText(QString("on %3 for %4").arg(_controller->server, _controller->onlineTime()));
 
     QString stationInfo = _controller->facilityString();
     if(!_controller->isObserver() && _controller->frequency.length() != 0)
         stationInfo += QString(" on frequency %1")
                 .arg(_controller->frequency);
-    lblStationInformatoin->setText(stationInfo);
+    lblStationInformation->setText(stationInfo);
 
     pbAirportDetails->setVisible(_controller->airport() != 0);
     pbAirportDetails->setText(   _controller->airport() != 0? _controller->airport()->toolTip(): "");
@@ -111,3 +108,11 @@ void ControllerDetails::closeEvent(QCloseEvent *event) {
     Settings::setControllerDetailsGeometry(saveGeometry());
     event->accept();
 }
+
+void ControllerDetails::on_pbAlias_clicked()
+{
+    if (_controller->showAliasDialog(this)) {
+        refresh();
+    }
+}
+

--- a/src/ControllerDetails.h
+++ b/src/ControllerDetails.h
@@ -24,6 +24,10 @@ class ControllerDetails: public ClientDetails, private Ui::ControllerDetails {
     private slots:
         void on_buttonAddFriend_clicked();
         void on_pbAirportDetails_clicked();
+
+        // @todo move to ClientDetails
+        void on_pbAlias_clicked();
+
     private:
         ControllerDetails(QWidget *parent);
         Controller* _controller;

--- a/src/ControllerDetails.ui
+++ b/src/ControllerDetails.ui
@@ -7,8 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>327</width>
-    <height>238</height>
+    <height>409</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+    <horstretch>1</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
@@ -26,31 +32,53 @@
      <property name="title">
       <string>Controller</string>
      </property>
-     <layout class="QVBoxLayout">
-      <property name="margin" stdset="0">
-       <number>6</number>
-      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QLabel" name="lblControllerInfo">
-        <property name="text">
-         <string>Donald Fauntleroy Duck (C3)
-On IVANIT for 01:23, IvAc 1.2.3</string>
-        </property>
-        <property name="openExternalLinks">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="detailsLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="lblStationInformatoin">
+         <widget class="QLabel" name="lblControllerInfo">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
-           <string>APP on frequency 123.45</string>
+           <string>&lt;a href=&quot;https://&quot;&gt;Donald Fauntleroy Duck (C3)&lt;/a&gt;</string>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pbAlias">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>alias…</string>
           </property>
          </widget>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QLabel" name="lblOnline">
+        <property name="text">
+         <string>On SERVER for 01:23</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="lblStationInformation">
+        <property name="text">
+         <string>APP on frequency 123.45</string>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QPushButton" name="pbAirportDetails">
@@ -85,7 +113,7 @@ On IVANIT for 01:23, IvAc 1.2.3</string>
          </sizepolicy>
         </property>
         <property name="text">
-         <string>TextLabel</string>
+         <string>ATIS</string>
         </property>
         <property name="textFormat">
          <enum>Qt::RichText</enum>

--- a/src/FriendsVisitor.cpp
+++ b/src/FriendsVisitor.cpp
@@ -7,13 +7,18 @@
 #include "Client.h"
 
 FriendsVisitor::FriendsVisitor() {
-	_friendList = Settings::friends();
+    _friendList = Settings::friends();
 }
 
 void FriendsVisitor::visit(MapObject* object) {
-	Client *c = dynamic_cast<Client*>(object);
-	if(c != 0) {
-		if(_friendList.contains(c->userId))
-			_friends.append(c);
-	}
+    Client *c = dynamic_cast<Client*>(object);
+    if(c != 0) {
+        if(c->isFriend()) {
+            _friends.append(c);
+        }
+    }
+}
+
+QList<MapObject *> FriendsVisitor::result() const {
+    return _friends;
 }

--- a/src/FriendsVisitor.h
+++ b/src/FriendsVisitor.h
@@ -15,7 +15,7 @@ class FriendsVisitor : public MapObjectVisitor {
     public:
         FriendsVisitor();
         virtual void visit(MapObject *object);
-        virtual QList<MapObject*> result() const { return _friends; }
+        virtual QList<MapObject*> result() const;
 
     private:
         QStringList _friendList;

--- a/src/ListClientsDialogModel.cpp
+++ b/src/ListClientsDialogModel.cpp
@@ -60,7 +60,7 @@ QVariant ListClientsDialogModel::data(const QModelIndex &index, int role) const 
         switch(index.column()) {
             case 0: return c->label;
             case 1: return c->rank();
-            case 2: return c->realName;
+            case 2: return c->realName();
             case 3: return c->onlineTime();
             case 4: return co != 0? QString("%1").arg(co->visualRange, 4, 'f', 0, ' '): QString();
             case 5:

--- a/src/PilotDetails.cpp
+++ b/src/PilotDetails.cpp
@@ -59,12 +59,9 @@ void PilotDetails::refresh(Pilot *pilot) {
     if (_pilot->server.isEmpty())
         lblConnected->setText(QString("<i>not connected</i>"));
     else
-        lblConnected->setText(QString("on %1 for %2%3")
-                     .arg(_pilot->server)
-                     .arg(_pilot->onlineTime())
-                     .arg(_pilot->clientInformation().isEmpty()? "": ", "+ _pilot->clientInformation()));
-    buttonShowOnMap->setEnabled(_pilot->lat != 0 || _pilot->lon != 0);
+        lblConnected->setText(QString("on %1 for %2").arg(_pilot->server, _pilot->onlineTime()));
 
+    buttonShowOnMap->setEnabled(_pilot->lat != 0 || _pilot->lon != 0);
 
     // Aircraft Information
     lblAircraft->setText(QString("%1").arg(_pilot->planAircraft));
@@ -148,12 +145,6 @@ void PilotDetails::on_buttonAddFriend_clicked() {
 
 void PilotDetails::on_cbPlotRoute_clicked(bool checked) {
     qDebug() << "PilotDetails::on_cbPlotRoute_clicked()" << checked;
-    bool plottedAirports = false; // plotted?
-    if (_pilot->depAirport() != 0)
-        plottedAirports |= _pilot->depAirport()->showFlightLines;
-    if (_pilot->destAirport() != 0)
-        plottedAirports |= _pilot->destAirport()->showFlightLines;
-
     if (_pilot->showDepDestLine != checked) {
         _pilot->showDepDestLine = checked;
         if (Window::instance(false) != 0) {
@@ -171,3 +162,11 @@ void PilotDetails::closeEvent(QCloseEvent *event) {
     Settings::setPilotDetailsGeometry(saveGeometry());
     event->accept();
 }
+
+void PilotDetails::on_pbAlias_clicked()
+{
+    if (_pilot->showAliasDialog(this)) {
+        refresh();
+    }
+}
+

--- a/src/PilotDetails.h
+++ b/src/PilotDetails.h
@@ -24,6 +24,10 @@ class PilotDetails : public ClientDetails, private Ui::PilotDetails {
         void on_buttonDest_clicked();
         void on_buttonFrom_clicked();
         void on_buttonAddFriend_clicked();
+
+        // @todo move to ClientDetails
+        void on_pbAlias_clicked();
+
     private:
         PilotDetails(QWidget *parent);
         Pilot *_pilot;

--- a/src/PilotDetails.ui
+++ b/src/PilotDetails.ui
@@ -26,27 +26,41 @@
      <property name="title">
       <string>Pilot</string>
      </property>
-     <layout class="QVBoxLayout">
-      <property name="spacing">
-       <number>1</number>
-      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QLabel" name="lblPilotInfo">
-        <property name="text">
-         <string>Surname Name, (EDDF)</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-        </property>
-        <property name="openExternalLinks">
-         <bool>true</bool>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <widget class="QLabel" name="lblPilotInfo">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Surname Name, (EDDF)</string>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pbAlias">
+          <property name="toolTip">
+           <string>Add or edit an alias for this VATSIM member</string>
+          </property>
+          <property name="text">
+           <string>alias…</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QLabel" name="lblConnected">
         <property name="text">
-         <string>on IVANDE for 1:41</string>
+         <string>on SERVER for 1:41</string>
         </property>
        </widget>
       </item>
@@ -87,7 +101,6 @@
          <widget class="QLabel" name="lblAircraft">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -117,7 +130,6 @@ source: data/airlines.dat or use Euroscopdata (Preferences/Special)</string>
          <widget class="QLabel" name="lblAirline">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -146,7 +158,7 @@ source: data/airlines.dat or use Euroscopdata (Preferences/Special)</string>
         <property name="spacing">
          <number>10</number>
         </property>
-        <property name="margin">
+        <property name="margin" stdset="0">
          <number>0</number>
         </property>
         <item>
@@ -166,7 +178,6 @@ source: data/airlines.dat or use Euroscopdata (Preferences/Special)</string>
          <widget class="QLabel" name="lblGroundspeed">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -195,7 +206,6 @@ source: data/airlines.dat or use Euroscopdata (Preferences/Special)</string>
          <widget class="QLabel" name="lblAltitude">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -221,7 +231,6 @@ source: data/airlines.dat or use Euroscopdata (Preferences/Special)</string>
          <widget class="QLabel" name="lblSquwak">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -284,7 +293,6 @@ delay: difference between planned and calculated ETA</string>
          <widget class="QLabel" name="label_3">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -303,7 +311,6 @@ delay: difference between planned and calculated ETA</string>
          <widget class="QLabel" name="label_4">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -322,7 +329,6 @@ delay: difference between planned and calculated ETA</string>
          <widget class="QLabel" name="lblPlanEta">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -347,7 +353,6 @@ delay: difference between planned and calculated ETA</string>
           </property>
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -368,7 +373,6 @@ delay: difference between planned and calculated ETA</string>
            <widget class="QLabel" name="lblPlanTas">
             <property name="font">
              <font>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -387,7 +391,6 @@ delay: difference between planned and calculated ETA</string>
            <widget class="QLabel" name="lblPlanFl">
             <property name="font">
              <font>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -405,7 +408,6 @@ delay: difference between planned and calculated ETA</string>
          <widget class="QLabel" name="label_2">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -421,7 +423,6 @@ delay: difference between planned and calculated ETA</string>
          <widget class="QLabel" name="lblPlanEte">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -448,7 +449,6 @@ delay: difference between planned and calculated ETA</string>
             </property>
             <property name="font">
              <font>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -477,7 +477,6 @@ delay: difference between planned and calculated ETA</string>
             </property>
             <property name="font">
              <font>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -626,7 +625,6 @@ delay: difference between planned and calculated ETA</string>
          <widget class="QLabel" name="label_6">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -662,7 +660,6 @@ route</string>
          <widget class="QLabel" name="label">
           <property name="font">
            <font>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>

--- a/src/SearchResultModel.cpp
+++ b/src/SearchResultModel.cpp
@@ -6,6 +6,10 @@
 
 #include "Window.h"
 
+SearchResultModel::SearchResultModel(QObject *parent):
+    QAbstractListModel(parent) {
+}
+
 int SearchResultModel::rowCount(const QModelIndex &parent) const {
     Q_UNUSED(parent);
     return _content.count();
@@ -18,53 +22,60 @@ int SearchResultModel::columnCount(const QModelIndex &parent) const {
 
 QVariant SearchResultModel::data(const QModelIndex &index, int role) const {
     if(!index.isValid() || index.row() >= _content.size())
-		return QVariant();
+        return QVariant();
 
-	if(role == Qt::DisplayRole) {
-		MapObject* o = _content[index.row()];
-		switch(index.column()) {
-			case 0: return o->toolTip(); break;
-		}
-	}
+    if(role == Qt::DisplayRole) {
+        MapObject* o = _content[index.row()];
+        switch(index.column()) {
+        case 0: return o->toolTip(); break;
+        }
+    }
 
-	if(role == Qt::FontRole) {
-		QFont result;
-		//prefiled italic
-		if(dynamic_cast<Pilot*>(_content[index.row()])) {
-			Pilot *p = dynamic_cast<Pilot*>(_content[index.row()]);
-			if(p->flightStatus() == Pilot::PREFILED) {
-				result.setItalic(true);
-			}
-		}
+    if(role == Qt::FontRole) {
+        QFont result;
+        //prefiled italic
+        if(dynamic_cast<Pilot*>(_content[index.row()])) {
+            Pilot *p = dynamic_cast<Pilot*>(_content[index.row()]);
+            if(p->flightStatus() == Pilot::PREFILED) {
+                result.setItalic(true);
+            }
+        }
 
-		//friends bold
-		Client *c = dynamic_cast<Client*>(_content[index.row()]);
-		if(c != 0) {
-			if(c->isFriend()) {
-				result.setBold(true);
-			}
-		}
-		return result;
-	}
+        //friends bold
+        Client *c = dynamic_cast<Client*>(_content[index.row()]);
+        if(c == 0) return QVariant();
 
-	return QVariant();
+        if(c->isFriend()) {
+            result.setBold(true);
+        }
+        return result;
+    }
+
+    return QVariant();
 }
 
 QVariant SearchResultModel::headerData(int section, enum Qt::Orientation orientation, int role) const {
-	if (role != Qt::DisplayRole)
-		return QVariant();
+    if (role != Qt::DisplayRole)
+        return QVariant();
 
-	if (orientation == Qt::Vertical)
-		return QVariant();
+    if (orientation == Qt::Vertical)
+        return QVariant();
 
-	if (section != 0)
-		return QVariant();
+    if (section != 0)
+        return QVariant();
 
-	if (_content.isEmpty())
-		return QString("No Results");
+    if (_content.isEmpty())
+        return QString("No Results");
+
     return QString("%1 Result%2").arg(_content.size()).arg(_content.size() == 1? "": "s");
 }
 
-void SearchResultModel::modelClicked(const QModelIndex& index) { // one click to bring up the detailsDialog
+void SearchResultModel::setSearchResults(const QList<MapObject *> &searchResult) {
+    beginResetModel();
+    _content = searchResult;
+    endResetModel();
+}
+
+void SearchResultModel::modelClicked(const QModelIndex& index) {
     _content[index.row()]->showDetailsDialog();
 }

--- a/src/SearchResultModel.h
+++ b/src/SearchResultModel.h
@@ -13,16 +13,16 @@ class SearchResultModel: public QAbstractListModel {
         Q_OBJECT
 
     public:
-        SearchResultModel(QObject *parent = 0): QAbstractListModel(parent) {}
+        SearchResultModel(QObject *parent = 0);
 
-        virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
-        virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
+        virtual int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+        virtual int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
-        virtual QVariant data(const QModelIndex &index, int role) const;
+        virtual QVariant data(const QModelIndex &index, int role) const override;
         virtual QVariant headerData(int section, Qt::Orientation orientation,
-                                    int role = Qt::DisplayRole) const;
+                                    int role = Qt::DisplayRole) const override;
     public slots:
-        void setSearchResults(const QList<MapObject*>& searchResult) { beginResetModel(); _content = searchResult; endResetModel(); }
+        void setSearchResults(const QList<MapObject*>& searchResult);
         void modelClicked(const QModelIndex& index);
 
     private:

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -7,6 +7,9 @@
 
 #include "Whazzup.h"
 #include "Window.h"
+#include "PilotDetails.h"
+#include "ControllerDetails.h"
+#include "AirportDetails.h"
 
 QSettings *settingsInstance = 0;
 QSettings* Settings::instance() {
@@ -1003,7 +1006,7 @@ QPoint Settings::savedPosition() {
     return instance()->value("mainWindowState/position", QPoint()).toPoint();
 }
 
-QStringList Settings::friends() {
+const QStringList Settings::friends() {
     return instance()->value("friends/friendList", QStringList()).toStringList();
 }
 
@@ -1020,6 +1023,45 @@ void Settings::removeFriend(const QString& friendId) {
     if(i >= 0 && i < fl.size())
         fl.removeAt(i);
     instance()->setValue("friends/friendList", fl);
+}
+
+const QString Settings::clientAlias(const QString &userId)
+{
+    return instance()->value(
+        QString("clients/alias_%1").arg(userId)
+    ).toString();
+}
+
+void Settings::setClientAlias(const QString &userId, const QString &alias)
+{
+    if (alias.isEmpty()) {
+        instance()->remove(
+            QString("clients/alias_%1").arg(userId)
+        );
+    } else {
+        instance()->setValue(
+            QString("clients/alias_%1").arg(userId),
+            alias
+        );
+    }
+
+    // should maybe use signals instead
+    if (Window::instance(false) != 0) {
+        Window::instance()->friendsList->reset();
+        Window::instance()->searchResult->reset();
+    }
+
+    if (PilotDetails::instance(false) != 0) {
+        PilotDetails::instance()->refresh();
+    }
+
+    if (ControllerDetails::instance(false) != 0) {
+        ControllerDetails::instance()->refresh();
+    }
+
+    if (AirportDetails::instance(false) != 0) {
+        AirportDetails::instance()->refresh();
+    }
 }
 
 bool Settings::resetOnNextStart() {

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -342,9 +342,12 @@ class Settings {
         static bool simpleLabels();
         static void setSimpleLabels(bool value);
 
-        static QStringList friends();
+        static const QStringList friends();
         static void addFriend(const QString& friendId);
         static void removeFriend(const QString& friendId);
+
+        static const QString clientAlias(const QString& userId);
+        static void setClientAlias(const QString& userId, const QString& alias = QString());
 
         static bool resetOnNextStart();
         static void setResetOnNextStart(bool value);

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -191,7 +191,7 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data):
             QJsonObject controllerObject;
 
             controllerObject["callsign"] = bc->label;
-            controllerObject["name"] = bc->realName;
+            controllerObject["name"] = bc->realName();
             controllerObject["facility"] = bc->facilityType;
 
             //atisMessage = getField(stringList, 35);

--- a/src/Window.ui
+++ b/src/Window.ui
@@ -393,7 +393,7 @@ Whazzups (replay)</string>
      <x>0</x>
      <y>0</y>
      <width>950</width>
-     <height>19</height>
+     <height>22</height>
     </rect>
    </property>
    <property name="statusTip">
@@ -690,7 +690,7 @@ Whazzups (replay)</string>
      <item>
       <widget class="QTreeView" name="friendsList">
        <property name="toolTip">
-        <string>Friends can be added via each controller or pilot detail dialogs.</string>
+        <string>Friends can be added via controller or pilot detail dialogs.</string>
        </property>
        <property name="rootIsDecorated">
         <bool>false</bool>


### PR DESCRIPTION
Since it is now permitted to be online at VATSIM without a name, you can now add an alias for a friend that is shown in addition to the login name.

In order to add an alias, double-click an entry in the friends list.

Fixes #62


I am not sure about the usability yet - double clicking is a bit weird because single click already opens the client dialog.

![image](https://user-images.githubusercontent.com/1678001/154142395-718889d6-17a6-4155-8b1b-7ff10b4112fd.png)