### PR TITLE
Use status.json insetad of status.ini

### DIFF
--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -410,11 +410,9 @@ void PreferencesDialog::on_cbNetwork_currentIndexChanged(int index) {
 
     switch(index) {
     case 0: // VATSIM
-        Settings::setStatusLocation("https://status.vatsim.net/status.json");
         gbDownloadBookings->setChecked(true);
         break;
     case 1: // user defined
-        Settings::setStatusLocation(editUserDefinedLocation->text());
         gbDownloadBookings->setChecked(false);
         break;
     }
@@ -427,7 +425,7 @@ void PreferencesDialog::on_editUserDefinedLocation_editingFinished() {
     if (!_settingsLoaded)
         return;
     Settings::setUserDownloadLocation(editUserDefinedLocation->text());
-    Settings::setStatusLocation(editUserDefinedLocation->text());
+    Settings::setDownloadNetwork(Settings::downloadNetwork()); // To force a reload of the status data
 }
 
 void PreferencesDialog::on_cbSaveWhazzupData_stateChanged(int state) {

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -410,7 +410,7 @@ void PreferencesDialog::on_cbNetwork_currentIndexChanged(int index) {
 
     switch(index) {
     case 0: // VATSIM
-        Settings::setStatusLocation("http://status.vatsim.net/");
+        Settings::setStatusLocation("http://status.vatsim.net/status.json");
         gbDownloadBookings->setChecked(true);
         break;
     case 1: // user defined

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -410,7 +410,7 @@ void PreferencesDialog::on_cbNetwork_currentIndexChanged(int index) {
 
     switch(index) {
     case 0: // VATSIM
-        Settings::setStatusLocation("http://status.vatsim.net/status.json");
+        Settings::setStatusLocation("https://status.vatsim.net/status.json");
         gbDownloadBookings->setChecked(true);
         break;
     case 1: // user defined

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -185,7 +185,7 @@ void Settings::setUpdateVersionNumber(const QString& version) {
 }
 
 QString Settings::statusLocation() {
-    return instance()->value("download/statusLocation", "http://status.vatsim.net/status.json").toString();
+    return instance()->value("download/statusLocation", "https://status.vatsim.net/status.json").toString();
 }
 
 void Settings::setStatusLocation(const QString& location) {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -19,7 +19,12 @@ QSettings* Settings::instance() {
         const int requiredSettingsVersion = 1;
         const int currentSettingsVersion = settingsInstance->value("settings/version", 0).toInt();
         if (currentSettingsVersion < requiredSettingsVersion) {
-            // do migration steps here
+            if((settingsInstance->value("download/network", 0).toInt() == 1)
+            && (settingsInstance->value("download/statusLocation", "").toString() == "http://status.vatsim.net/")) {
+                settingsInstance->setValue("download/network", 0);
+                qDebug() << "Found a user defined network, but VATSIM status location. Migrated.";
+            }
+            settingsInstance->remove("download/statusLocation");
             settingsInstance->setValue("settings/version", requiredSettingsVersion);
         }
     }
@@ -137,11 +142,12 @@ void Settings::setBookingsInterval(int value) {
 }
 
 int Settings::downloadNetwork() {
-    return instance()->value("download/network", 1).toInt();
+    return instance()->value("download/network", 0).toInt();
 }
 
 void Settings::setDownloadNetwork(int i) {
     instance()->setValue("download/network", i);
+    Whazzup::instance()->setStatusLocation(statusLocation());
 }
 
 QString Settings::downloadNetworkName() {
@@ -185,12 +191,12 @@ void Settings::setUpdateVersionNumber(const QString& version) {
 }
 
 QString Settings::statusLocation() {
-    return instance()->value("download/statusLocation", "https://status.vatsim.net/status.json").toString();
-}
-
-void Settings::setStatusLocation(const QString& location) {
-    instance()->setValue("download/statusLocation", location);
-    Whazzup::instance()->setStatusLocation(location);
+    switch(downloadNetwork()) {
+        case 0: // VATSIM
+            return "https://status.vatsim.net/status.json";
+        case 1: // user defined
+            return userDownloadLocation();
+    }
 }
 
 bool Settings::useProxy() {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -185,7 +185,7 @@ void Settings::setUpdateVersionNumber(const QString& version) {
 }
 
 QString Settings::statusLocation() {
-    return instance()->value("download/statusLocation", "http://status.vatsim.net/").toString();
+    return instance()->value("download/statusLocation", "http://status.vatsim.net/status.json").toString();
 }
 
 void Settings::setStatusLocation(const QString& location) {

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -48,7 +48,6 @@ class Settings {
         static QString userDownloadLocation();
         static void setUserDownloadLocation(const QString& location);
         static QString statusLocation();
-        static void setStatusLocation(const QString& location);
         static QString bookingsLocation();
         static void setBookingsLocation(const QString& value);
         static bool downloadBookings();


### PR DESCRIPTION
See #53
This currently has the following issues:
* It requires the user to manually go to the settings and reselect VATSIM as a network to update the URL to http://status.vatsim.net/status.json (Edit: Additionally this should probably use https right away)
* The server URL isn't extracted, because the new server file is also in .json format. I'm not sure whether the servers are ever actually queried from the server URL by QuteScoop, since the servers are also in the v3 data.
* Only one METAR and User status URL are extracted. In the status.ini format there was only one URL specified, however in the status.json there is an array. Unfortunately the documentation for the API seems to be down, so I can't check what the intended behaviour is.
* moveto0 and msg0 aren't extracted, since I don't know where in the JSON these are supposed to be. Again unfortunately the API documentation seems to be offline.

The last two points can be fixed once the API doc is back online, however I'd like your input on how to deal with the first two points.