### PR TITLE
[FEATURE] modernize default theme

### DIFF
--- a/src/Airport.h
+++ b/src/Airport.h
@@ -50,7 +50,6 @@ class Airport: public MapObject {
         bool showFlightLines;
 
         const GLuint &appDisplayList();
-        const GLuint &appBorderDisplayList();
         const GLuint &twrDisplayList();
         const GLuint &gndDisplayList();
         const GLuint &delDisplayList();
@@ -58,7 +57,7 @@ class Airport: public MapObject {
         Metar metar;
 
     private:
-        GLuint _appDisplayList, _appBorderDisplayList, _twrDisplayList,
+        GLuint _appDisplayList, _twrDisplayList,
         _gndDisplayList, _delDisplayList;
 };
 

--- a/src/GLWidget.h
+++ b/src/GLWidget.h
@@ -118,7 +118,7 @@ class GLWidget : public QGLWidget {
         _earthList, _coastlinesList, _countriesList, _gridlinesList,
         _pilotsList, _activeAirportsList, _inactiveAirportsList,
         _fixesList, _usedWaypointsList, _plannedRouteList,
-        _sectorPolygonsList, _sectorPolygonBorderLinesList, _appBorderLinesList, _congestionsList,
+        _sectorPolygonsList, _sectorPolygonBorderLinesList, _congestionsList,
         _staticSectorPolygonsList, _staticSectorPolygonBorderLinesList,
         _hoveredSectorPolygonsList, _hoveredSectorPolygonBorderLinesList;
         QSet<Controller*> _sectorsToDraw, _hoveredControllers;

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -209,7 +209,7 @@ void PreferencesDialog::loadSettings() {
     color = Settings::appBorderLineColor();
     pbAppBorderLineColor->setText(color.name());
     pbAppBorderLineColor->setPalette(QPalette(color));
-    sbAppBorderLineStrength->setValue(Settings::appBorderLineStrength());
+    sbAppBorderLineStrength->setValue(Settings::appBorderLineWidth());
 
     color = Settings::appCenterColor();
     pbAppColorCenter->setText(color.name());
@@ -230,7 +230,7 @@ void PreferencesDialog::loadSettings() {
     color = Settings::gndBorderLineColor();
     pbGndBorderLineColor->setText(color.name());
     pbGndBorderLineColor->setPalette(QPalette(color));
-    sbGndBorderLineStrength->setValue(Settings::gndBorderLineStrength());
+    sbGndBorderLineStrength->setValue(Settings::gndBorderLineWidth());
 
     color = Settings::gndFillColor();
     pbGndFillColor->setText(color.name());
@@ -257,7 +257,7 @@ void PreferencesDialog::loadSettings() {
     pbPilotDotColor->setPalette(QPalette(color));
     sbPilotDotSize->setValue(Settings::pilotDotSize());
 
-    color = Settings::timeLineColor();
+    color = Settings::leaderLineColor();
     pbTimeLineColor->setText(color.name());
     pbTimeLineColor->setPalette(QPalette(color));
     sbTimeLineStrength->setValue(Settings::timeLineStrength());
@@ -298,8 +298,8 @@ void PreferencesDialog::loadSettings() {
 
     //highlight Friends
     sb_highlightFriendsLineWidth->setValue(Settings::highlightLineWidth());
-    pb_highlightFriendsColor->setPalette(QPalette(Settings::highlightColor()));
-    pb_highlightFriendsColor->setText(Settings::highlightColor().name());
+    pb_highlightFriendsColor->setPalette(QPalette(Settings::friendsHighlightColor()));
+    pb_highlightFriendsColor->setText(Settings::friendsHighlightColor().name());
     cb_Animation->setChecked(Settings::useHighlightAnimation());
 
     // FINISHED
@@ -819,12 +819,12 @@ void PreferencesDialog::on_sbPilotDotSize_valueChanged(double value) {
 }
 
 void PreferencesDialog::on_pbTimeLineColor_clicked() {
-    QColor color = QColorDialog::getColor(Settings::timeLineColor(), this,
+    QColor color = QColorDialog::getColor(Settings::leaderLineColor(), this,
                                           "Select color", QColorDialog::ShowAlphaChannel);
     if(color.isValid()) {
         pbTimeLineColor->setText(color.name());
         pbTimeLineColor->setPalette(QPalette(color));
-        Settings::setTimeLineColor(color);
+        Settings::setLeaderLineColor(color);
     }
 }
 
@@ -1302,13 +1302,13 @@ void PreferencesDialog::on_cb_Animation_stateChanged(int state) {
 }
 
 void PreferencesDialog::on_pb_highlightFriendsColor_clicked() {
-    QColor color = QColorDialog::getColor(Settings::backgroundColor(), this,
+    QColor color = QColorDialog::getColor(Settings::friendsHighlightColor(), this,
                                           "Select color", QColorDialog::ShowAlphaChannel);
 
     if(color.isValid()) {
         pb_highlightFriendsColor->setText(color.name());
         pb_highlightFriendsColor->setPalette(QPalette(color));
-        Settings::setHighlightColor(color);
+        Settings::setFriendsHighlightColor(color);
     }
 }
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -570,7 +570,7 @@ void Settings::setCoastLineStrength(double strength) {
 
 // FIRs
 QColor Settings::firBorderLineColor() {
-    return instance()->value("firDisplay/borderLineColor", QColor::fromRgbF(0.0, 0.0, 1.0, 0.3)).value<QColor>();
+    return instance()->value("firDisplay/borderLineColor", QColor::fromRgb(42, 163, 214, 120)).value<QColor>();
 }
 
 void Settings::setFirBorderLineColor(const QColor& color) {
@@ -615,7 +615,7 @@ void Settings::setFirFont(const QFont& font) {
 }
 
 QColor Settings::firHighlightedBorderLineColor() {
-    return instance()->value("firDisplay/borderLineColorHighlighted", QColor::fromRgbF(1.0, 1.0, 0.5, 0.3)).value<QColor>();
+    return instance()->value("firDisplay/borderLineColorHighlighted", QColor::fromRgb(200, 13, 214, 77)).value<QColor>();
 }
 
 void Settings::setFirHighlightedBorderLineColor(const QColor& color) {
@@ -631,7 +631,7 @@ void Settings::setFirHighlightedBorderLineStrength(double strength) {
 }
 
 QColor Settings::firHighlightedFillColor() {
-    return instance()->value("firDisplay/fillColorHighlighted", QColor::fromRgb(200, 13, 214, 50)).value<QColor>();
+    return instance()->value("firDisplay/fillColorHighlighted", QColor::fromRgb(200, 13, 214, 35)).value<QColor>();
 }
 
 void Settings::setFirHighlightedFillColor(const QColor& color) {
@@ -703,21 +703,20 @@ QFont Settings::inactiveAirportFont() {
     result.setStyleHint( QFont::SansSerif, QFont::PreferAntialias );
     return result;
 }
+
 void Settings::setInactiveAirportFont(const QFont& font) {
     instance()->setValue("airportDisplay/inactiveFont", font);
 }
 
-
-
 QColor Settings::appBorderLineColor() {
-    return instance()->value("airportDisplay/appBorderLineColor", QColor::fromRgb(255, 255, 127)).value<QColor>();
+    return instance()->value("airportDisplay/appBorderLineColor", QColor::fromRgb(42, 163, 214, 120)).value<QColor>();
 }
 
 void Settings::setAppBorderLineColor(const QColor& color) {
     instance()->setValue("airportDisplay/appBorderLineColor", color);
 }
 
-double Settings::appBorderLineStrength() {
+double Settings::appBorderLineWidth() {
     return instance()->value("airportDisplay/appBorderLineStrength", 1.5).toDouble();
 }
 
@@ -726,7 +725,7 @@ void Settings::setAppBorderLineStrength(double value) {
 }
 
 QColor Settings::appCenterColor() {
-    return instance()->value("airportDisplay/appCenterColor", QColor::fromRgbF(0.0, 0.0, 1.0, 0.0)).value<QColor>();
+    return instance()->value("airportDisplay/appCenterColor", QColor::fromRgb(0, 0, 0, 0)).value<QColor>();
 }
 
 void Settings::setAppCenterColor(const QColor& color) {
@@ -734,39 +733,39 @@ void Settings::setAppCenterColor(const QColor& color) {
 }
 
 QColor Settings::appMarginColor() {
-    return instance()->value("airportDisplay/appMarginColor", QColor::fromRgb(85, 170, 255)).value<QColor>();
+    return instance()->value("airportDisplay/appMarginColor", QColor::fromRgb(34, 85, 99, 128)).value<QColor>();
 }
 
 void Settings::setAppMarginColor(const QColor& color) {
     instance()->setValue("airportDisplay/appMarginColor", color);
 }
 
-QColor Settings::twrMarginColor() {
-    return instance()->value("airportDisplay/twrMarginColor", QColor::fromRgb(102, 85, 67)).value<QColor>();
-}
-
-void Settings::setTwrMarginColor(const QColor& color) {
-    instance()->setValue("airportDisplay/twrMarginColor", color);
-}
-
 QColor Settings::twrCenterColor() {
-    return instance()->value("airportDisplay/twrCenterColor", QColor::fromRgbF(0.8, 0.8, 0.0, 0.0)).value<QColor>();
+    return instance()->value("airportDisplay/twrCenterColor", QColor::fromRgb(34, 85, 99, 10)).value<QColor>();
 }
 
 void Settings::setTwrCenterColor(const QColor& color) {
     instance()->setValue("airportDisplay/twrCenterColor", color);
 }
 
+QColor Settings::twrMarginColor() {
+    return instance()->value("airportDisplay/twrMarginColor", QColor::fromRgb(34, 85, 99, 200)).value<QColor>();
+}
+
+void Settings::setTwrMarginColor(const QColor& color) {
+    instance()->setValue("airportDisplay/twrMarginColor", color);
+}
+
 QColor Settings::gndBorderLineColor() {
-    return instance()->value("airportDisplay/gndBorderLineColor", QColor::fromRgb(179, 0, 179)).value<QColor>();
+    return instance()->value("airportDisplay/gndBorderLineColor", QColor::fromRgb(255, 255, 127, 40)).value<QColor>();
 }
 
 void Settings::setGndBorderLineColor(const QColor& color) {
     instance()->setValue("airportDisplay/gndBorderLineColor", color);
 }
 
-double Settings::gndBorderLineStrength() {
-    return instance()->value("airportDisplay/gndBorderLineStrength", 0.2).toDouble();
+double Settings::gndBorderLineWidth() {
+    return instance()->value("airportDisplay/gndBorderLineStrength", 1.0).toDouble();
 }
 
 void Settings::setGndBorderLineStrength(double value) {
@@ -774,12 +773,69 @@ void Settings::setGndBorderLineStrength(double value) {
 }
 
 QColor Settings::gndFillColor() {
-    return instance()->value("airportDisplay/gndFillColor", QColor::fromRgb(255, 255, 127)).value<QColor>();
+    return instance()->value("airportDisplay/gndFillColor", QColor::fromRgb(12, 30, 35, 186)).value<QColor>();
 }
 
 void Settings::setGndFillColor(const QColor& color) {
     instance()->setValue("airportDisplay/gndFillColor", color);
 }
+
+// Airport traffic
+bool Settings::filterTraffic() {
+    return instance()->value("airportTraffic/filterTraffic", true).toBool();
+}
+
+void Settings::setFilterTraffic(bool v) {
+    instance()->setValue("airportTraffic/filterTraffic", v);
+}
+
+int Settings::filterDistance() {
+    return instance()->value("airportTraffic/filterDistance", 5).toInt();
+}
+
+void Settings::setFilterDistance(int v) {
+    instance()->setValue("airportTraffic/filterDistance", v);
+}
+
+double Settings::filterArriving() {
+    return instance()->value("airportTraffic/filterArriving", 1.0).toDouble();
+}
+
+void Settings::setFilterArriving(double v) {
+    instance()->setValue("airportTraffic/filterArriving", v);
+}
+// airport congestion
+bool Settings::showAirportCongestion() {
+    return instance()->value("airportTraffic/showCongestion", true).toBool();
+}
+void Settings::setAirportCongestion(bool value) {
+    instance()->setValue("airportTraffic/showCongestion", value);
+}
+
+int Settings::airportCongestionMinimum() {
+    return instance()->value("airportTraffic/minimumMovements", 8).toInt();
+}
+
+void Settings::setAirportCongestionMinimum(int value) {
+    instance()->setValue("airportTraffic/minimumMovements", value);
+}
+
+QColor Settings::airportCongestionBorderLineColor() {
+    return instance()->value("airportTraffic/borderLineColor", QColor::fromRgb(255, 0, 127, 103)).value<QColor>();
+}
+
+void Settings::setAirportCongestionBorderLineColor(const QColor& color) {
+    instance()->setValue("airportTraffic/borderLineColor", color);
+}
+
+double Settings::airportCongestionBorderLineStrength() {
+    return instance()->value("airportTraffic/borderLineStrength", 2).toDouble();
+}
+
+void Settings::setAirportCongestionBorderLineStrength(double value) {
+    instance()->setValue("airportTraffic/borderLineStrength", value);
+}
+
 
 // pilot
 QColor Settings::pilotFontColor() {
@@ -800,18 +856,8 @@ void Settings::setPilotFont(const QFont& font) {
     instance()->setValue("pilotDisplay/font", font);
 }
 
-QFont Settings::sondeFont() {
-    QFont defaultFont;
-    defaultFont.setPixelSize(9);
-    return instance()->value("sondeDisplay/font", defaultFont).value<QFont>();
-}
-
-void Settings::setSondeFont(const QFont& font) {
-    instance()->setValue("sondeDisplay/font", font);
-}
-
 QColor Settings::pilotDotColor() {
-    return instance()->value("pilotDisplay/dotColor", QColor::fromRgb(255, 0, 127)).value<QColor>();
+    return instance()->value("pilotDisplay/dotColor", QColor::fromRgb(255, 0, 127, 100)).value<QColor>();
 }
 
 void Settings::setPilotDotColor(const QColor& color) {
@@ -833,10 +879,10 @@ void Settings::setTimelineSeconds(int value) {
     instance()->setValue("pilotDisplay/timelineSeconds", value);
 }
 
-QColor Settings::timeLineColor() {
-    return instance()->value("pilotDisplay/timeLineColor", QColor::fromRgb(255, 0, 127)).value<QColor>();
+QColor Settings::leaderLineColor() {
+    return instance()->value("pilotDisplay/timeLineColor", QColor::fromRgb(255, 0, 127, 80)).value<QColor>();
 }
-void Settings::setTimeLineColor(const QColor& color) {
+void Settings::setLeaderLineColor(const QColor& color) {
     instance()->setValue("pilotDisplay/timeLineColor", color);
 }
 
@@ -848,6 +894,18 @@ void Settings::setTimeLineStrength(double value) {
     instance()->setValue("pilotDisplay/timeLineStrength", value);
 }
 
+// Wind
+QFont Settings::sondeFont() {
+    QFont defaultFont;
+    defaultFont.setPixelSize(9);
+    return instance()->value("sondeDisplay/font", defaultFont).value<QFont>();
+}
+
+void Settings::setSondeFont(const QFont& font) {
+    instance()->setValue("sondeDisplay/font", font);
+}
+
+// Waypoints
 bool Settings::showUsedWaypoints() {
     return instance()->value("display/showUsedWaypoints", false).toBool();
 }
@@ -887,9 +945,9 @@ void Settings::setWaypointsFont(const QFont& font) {
     instance()->setValue("pilotDisplay/waypointsFont", font);
 }
 
-
+// routes
 QColor Settings::depLineColor() {
-    return instance()->value("pilotDisplay/depLineColor", QColor::fromRgb(170, 255, 127, 150)).value<QColor>();
+    return instance()->value("pilotDisplay/depLineColor", QColor::fromRgb(170, 255, 127, 100)).value<QColor>();
 }
 
 void Settings::setDepLineColor(const QColor& color) {
@@ -897,19 +955,19 @@ void Settings::setDepLineColor(const QColor& color) {
 }
 
 QColor Settings::destLineColor() {
-    return instance()->value("pilotDisplay/destLineColor", QColor::fromRgb(255, 170, 0, 150)).value<QColor>();
+    return instance()->value("pilotDisplay/destLineColor", QColor::fromRgb(255, 170, 0, 100)).value<QColor>();
 }
 
 void Settings::setDestLineColor(const QColor& color) {
     instance()->setValue("pilotDisplay/destLineColor", color);
 }
 
-void Settings::setDepLineDashed(bool value) {
-    instance()->setValue("pilotDisplay/depLineDashed", value);
+bool Settings::depLineDashed() {
+    return instance()->value("pilotDisplay/depLineDashed", true).toBool();
 }
 
-bool Settings::depLineDashed() {
-    return instance()->value("pilotDisplay/depLineDashed", false).toBool();
+void Settings::setDepLineDashed(bool value) {
+    instance()->setValue("pilotDisplay/depLineDashed", value);
 }
 
 void Settings::setDestLineDashed(bool value) {
@@ -917,11 +975,11 @@ void Settings::setDestLineDashed(bool value) {
 }
 
 bool Settings::destLineDashed() {
-    return instance()->value("pilotDisplay/destLineDashed", true).toBool();
+    return instance()->value("pilotDisplay/destLineDashed", false).toBool();
 }
 
 double Settings::depLineStrength() {
-    return instance()->value("pilotDisplay/depLineStrength", 1.5).toDouble();
+    return instance()->value("pilotDisplay/depLineStrength", 0.8).toDouble();
 }
 
 void Settings::setDepLineStrength(double value) {
@@ -997,15 +1055,15 @@ QByteArray Settings::savedGeometry() {
     return instance()->value("mainWindowState/geometry", QByteArray()).toByteArray();
 }
 
-QColor Settings::highlightColor() {
-    return instance()->value("pilotDisplay/highlightColor", QColor::fromRgb(255, 0 , 0, 255)).value<QColor>();
+QColor Settings::friendsHighlightColor() {
+    return instance()->value("pilotDisplay/highlightColor", QColor::fromRgb(255, 255, 127, 180)).value<QColor>();
 }
-void Settings::setHighlightColor(QColor &color) {
+void Settings::setFriendsHighlightColor(QColor &color) {
     instance()->setValue("pilotDisplay/highlightColor", color);
 }
 
 double Settings::highlightLineWidth() {
-    return instance()->value("pilotDisplay/highlightLineWidth" , 1.5).toDouble();
+    return instance()->value("pilotDisplay/highlightLineWidth" , 2.5).toDouble();
 }
 void Settings::setHighlightLineWidth(double value) {
     instance()->setValue("pilotDisplay/highlightLineWidth", value);
@@ -1100,61 +1158,6 @@ void Settings::setResetOnNextStart(bool value) {
     instance()->setValue("main/resetConfiguration", value);
 }
 
-// Airport traffic
-bool Settings::filterTraffic() {
-    return instance()->value("airportTraffic/filterTraffic", true).toBool();
-}
-
-void Settings::setFilterTraffic(bool v) {
-    instance()->setValue("airportTraffic/filterTraffic", v);
-}
-
-int Settings::filterDistance() {
-    return instance()->value("airportTraffic/filterDistance", 5).toInt();
-}
-
-void Settings::setFilterDistance(int v) {
-    instance()->setValue("airportTraffic/filterDistance", v);
-}
-
-double Settings::filterArriving() {
-    return instance()->value("airportTraffic/filterArriving", 1.0).toDouble();
-}
-
-void Settings::setFilterArriving(double v) {
-    instance()->setValue("airportTraffic/filterArriving", v);
-}
-// airport congestion
-bool Settings::showAirportCongestion() {
-    return instance()->value("airportTraffic/showCongestion", true).toBool();
-}
-void Settings::setAirportCongestion(bool value) {
-    instance()->setValue("airportTraffic/showCongestion", value);
-}
-
-int Settings::airportCongestionMinimum() {
-    return instance()->value("airportTraffic/minimumMovements", 8).toInt();
-}
-
-void Settings::setAirportCongestionMinimum(int value) {
-    instance()->setValue("airportTraffic/minimumMovements", value);
-}
-
-QColor Settings::airportCongestionBorderLineColor() {
-    return instance()->value("airportTraffic/borderLineColor", QColor::fromRgb(255, 0, 127, 150)).value<QColor>();
-}
-
-void Settings::setAirportCongestionBorderLineColor(const QColor& color) {
-    instance()->setValue("airportTraffic/borderLineColor", color);
-}
-
-double Settings::airportCongestionBorderLineStrength() {
-    return instance()->value("airportTraffic/borderLineStrength", 2).toDouble();
-}
-
-void Settings::setAirportCongestionBorderLineStrength(double value) {
-    instance()->setValue("airportTraffic/borderLineStrength", value);
-}
 
 // zooming
 int Settings::wheelMax() {

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -243,7 +243,7 @@ class Settings {
         static QColor appBorderLineColor();
         static void setAppBorderLineColor(const QColor& color);
 
-        static double appBorderLineStrength();
+        static double appBorderLineWidth();
         static void setAppBorderLineStrength(double value);
 
         static QColor appCenterColor();
@@ -261,7 +261,7 @@ class Settings {
         static QColor gndBorderLineColor();
         static void setGndBorderLineColor(const QColor& color);
 
-        static double gndBorderLineStrength();
+        static double gndBorderLineWidth();
         static void setGndBorderLineStrength(double value);
 
         static QColor gndFillColor();
@@ -279,8 +279,8 @@ class Settings {
         static double pilotDotSize();
         static void setPilotDotSize(double value);
 
-        static QColor timeLineColor();
-        static void setTimeLineColor(const QColor& color);
+        static QColor leaderLineColor();
+        static void setLeaderLineColor(const QColor& color);
 
         static bool showUsedWaypoints();
         static void setShowUsedWaypoints(bool value);
@@ -318,8 +318,8 @@ class Settings {
         static bool destLineDashed();
         static void setDestLineDashed(bool value);
 
-        static QColor highlightColor();
-        static void setHighlightColor(QColor& color);
+        static QColor friendsHighlightColor();
+        static void setFriendsHighlightColor(QColor& color);
 
         static double highlightLineWidth();
         static void setHighlightLineWidth(double value);


### PR DESCRIPTION
This employs more transparency to most map objects.
It uses less colors and tries to strengthen a ball blue-purple color
profile with sun-yellow and celeste highlights.

This also reworks the representation of online GND and DEL stations at an airport.

![image](https://user-images.githubusercontent.com/1678001/155859267-8cef7d0b-2915-41f6-bedb-b9fe69be4c97.png)

Note: the TWR border is currently not customizable (it is the same as for APP). GND + DEL also still use the same style.

Feedback is welcome of course!