### PR TITLE
[TASK] update C++ code linting

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,6 +1,12 @@
 # Uncrustify-0.74.0
 
 #
+# Qt specific options
+#
+set FOR foreach
+set FOR forever
+
+#
 # General options
 #
 
@@ -125,7 +131,7 @@ sp_before_assign                = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space after assignment operator '=', '+=', etc.
 #
 # Overrides sp_assign.
-sp_after_assign                 = ignore   # ignore/add/remove/force/not_defined
+sp_after_assign                 = add   # ignore/add/remove/force/not_defined
 
 # Add or remove space in 'enum {'.
 #
@@ -189,7 +195,7 @@ sp_paren_brace                  = force   # ignore/add/remove/force/not_defined
 sp_brace_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before pointer star '*'.
-sp_before_ptr_star              = ignore   # ignore/add/remove/force/not_defined
+sp_before_ptr_star              = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before pointer star '*' that isn't followed by a
 # variable name. If set to ignore, sp_before_ptr_star is used instead.
@@ -201,7 +207,7 @@ sp_between_ptr_star             = remove   # ignore/add/remove/force/not_defined
 # Add or remove space after pointer star '*', if followed by a word.
 #
 # Overrides sp_type_func.
-sp_after_ptr_star               = remove   # ignore/add/remove/force/not_defined
+sp_after_ptr_star               = add   # ignore/add/remove/force/not_defined
 
 # Add or remove space after pointer caret '^', if followed by a word.
 sp_after_ptr_block_caret        = ignore   # ignore/add/remove/force/not_defined
@@ -249,7 +255,7 @@ sp_before_unnamed_byref         = remove   # ignore/add/remove/force/not_defined
 # Add or remove space after reference sign '&', if followed by a word.
 #
 # Overrides sp_type_func.
-sp_after_byref                  = remove   # ignore/add/remove/force/not_defined
+sp_after_byref                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after a reference sign '&', if followed by a function
 # prototype or function definition.
@@ -598,14 +604,14 @@ sp_trailing_return              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between return type and function name. A minimum of 1
 # is forced except for pointer return types.
-sp_type_func                    = ignore   # ignore/add/remove/force/not_defined
+sp_type_func                    = force   # ignore/add/remove/force/not_defined
 
 # Add or remove space between type and open brace of an unnamed temporary
 # direct-list-initialization.
 sp_type_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '(' on function declaration.
-sp_func_proto_paren             = ignore   # ignore/add/remove/force/not_defined
+sp_func_proto_paren             = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function declaration
 # without parameters.
@@ -1008,7 +1014,7 @@ sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force/not_defined
 sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a trailing comment.
-sp_before_tr_cmt                = ignore   # ignore/add/remove/force/not_defined
+sp_before_tr_cmt                = force   # ignore/add/remove/force/not_defined
 
 # Number of spaces before a trailing comment.
 sp_num_before_tr_cmt            = 0        # unsigned number
@@ -1055,7 +1061,7 @@ force_tab_after_define          = false    # true/false
 # The number of columns to indent per level. Usually 2, 3, 4, or 8.
 #
 # Default: 8
-indent_columns                  = 2        # unsigned number
+indent_columns                  = 4        # unsigned number
 
 # The continuation indent. If non-zero, this overrides the indent of '(', '['
 # and '=' continuation indents. Negative values are OK; negative value is
@@ -1527,7 +1533,7 @@ indent_off_after_return         = false    # true/false
 indent_off_after_return_new     = false    # true/false
 
 # If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.
-indent_single_after_return      = false    # true/false
+indent_single_after_return      = true    # true/false
 
 # Whether to ignore indent and alignment for 'asm' blocks (i.e. assume they
 # have their own indentation).
@@ -2434,7 +2440,7 @@ pos_arith                       = ignore   # ignore/break/force/lead/trail/join/
 pos_assign                      = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
 
 # The position of Boolean operators in wrapped expressions.
-pos_bool                        = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+pos_bool                        = lead   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
 
 # The position of comparison operators in wrapped expressions.
 pos_compare                     = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
@@ -2463,7 +2469,7 @@ pos_class_colon                 = ignore   # ignore/break/force/lead/trail/join/
 
 # The position of colons between constructor and member initialization.
 # Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
-pos_constr_colon                = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+pos_constr_colon                = trail_break   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
 
 # The position of shift operators in wrapped expressions.
 pos_shift                       = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
@@ -2829,7 +2835,7 @@ align_oc_msg_colon_xcode_like   = false    # true/false
 #
 
 # Try to wrap comments at N columns.
-cmt_width                       = 0        # unsigned number
+cmt_width                       = 120        # unsigned number
 
 # How to reflow comments.
 #
@@ -2875,7 +2881,7 @@ cmt_reflow_indent_to_paragraph_start = false    # true/false
 
 # Whether to convert all tabs to spaces in comments. If false, tabs in
 # comments are left alone, unless used for indenting.
-cmt_convert_tab_to_spaces       = false    # true/false
+cmt_convert_tab_to_spaces       = true    # true/false
 
 # Whether to apply changes to multi-line comments, including cmt_width,
 # keyword substitution and leading chars.


### PR DESCRIPTION
This updates the uncrustify config to a point that I really like.

It encompasses enforcing new lines when at least 1 function argument is on another line:
```
# no
  func(aLongFunctionArgument,
          b);
# yes
  func(
    aLongFunctionArgument,
    b
  );
```
It also enforces indenting by always the same amount, not aligning under the opening `(` etc.

The 2 space indent might be controversial, but I prefer it currently.

## todo
It is far from perfect though. 
I noted the alignment of `&` in function return declarations is funky.
