### PR TITLE
[BUGFIX] fix sector-contains-point at the longitude-wrap

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -61,11 +61,13 @@ Controller::Controller(const QJsonObject& json, const WhazzupData* whazzup):
                 //s->lat = lat; s->lon = lon; // position label on primary visibility center
                 s->icao = icao;
                 s->name = "no sector data";
+                QList<QPair<double, double> > pointList;
                 for(float u = 0.; u < 2. * M_PI; u += M_PI / 24.) { // 48 segments
-                    s->points.append(QPair<double, double>(lat + qCos(u) * visualRange / 2. / 60.,
+                    pointList.append(QPair<double, double>(lat + qCos(u) * visualRange / 2. / 60.,
                                                            lon + qSin(u) * visualRange / 2. / 60. /
                                                                 qCos(qAbs(lat) * Pi180)));
                 }
+                s->setPoints(pointList);
                 NavData::instance()->sectors.insert(icao, s); // adding to the pool
             } else
                 icao = icao.left(p);

--- a/src/Sector.h
+++ b/src/Sector.h
@@ -18,10 +18,11 @@ class Sector {
 
         bool isNull() const { return icao.isNull(); }
 
-        const QPolygonF sectorPolygon() const;
         bool containsPoint(const QPointF &pt) const;
 
-        QList<QPair<double, double> > points;
+        const QList<QPolygonF> &nonWrappedPolygons() const;
+        const QList<QPair<double, double> > &points() const;
+        void setPoints(const QList<QPair<double, double> >&);
         QString icao, name, id;
 
         GLuint glPolygon();
@@ -31,6 +32,8 @@ class Sector {
 
         QPair<double, double> getCenter() const;
     private:
+        QList<QPolygonF> m_nonWrappedPolygons;
+        QList<QPair<double, double> > m_points;
         GLuint _polygon, _borderline, _polygonHighlighted, _borderlineHighlighted;
 };
 

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -11,10 +11,14 @@
 typedef QPair<double, double> DoublePair;
 
 // modulo, but always positive, not like fmod()
-static double inline modPositive(double x, double y) {
+static float inline modPositive(float x, float y) {
     if (qFuzzyIsNull(y))
         return x;
     return x - y * floor(x/y);
+}
+
+static float lerp(float v0, float v1, float t) {
+    return v0 + t * (v1 - v0);
 }
 
 /* mathematical constants */


### PR DESCRIPTION
The problem is solved by splitting sectors at the +/-180 longitude
meridian and keeping both parts in memory.
Sector-contains-point checks can then use standard algorithms without
taking our wrapping problem into account.

This also moves data sanity checks into SectorReader and improves
performance during sector-contains-point checks by doing initialization
during the newly introduced `setPoints()` function. `points` has been
renamed to `m_points` and is now private.

It has been found that our `firdisplay` data does actually contain a lot
of unsanitized non-aligned (lon > 180 or lon < -180) longitude data.
This is now sanitized during loading so that none of our methods needs to
deal with it.

Resolves: #106
