### PR TITLE
[TASK] remove forced dialog resizing

### DIFF
--- a/src/ControllerDetails.cpp
+++ b/src/ControllerDetails.cpp
@@ -77,12 +77,13 @@ void ControllerDetails::refresh(Controller *newController) {
     pbAirportDetails->setVisible(_controller->airport() != 0);
     pbAirportDetails->setText(   _controller->airport() != 0? _controller->airport()->toolTip(): "");
 
-    QString atis = QString("<code>%1</code>").arg(_controller->atisMessage);
+    QString atis = QString("<code style='margin: 50px; padding: 50px'>%1</code>").arg(_controller->atisMessage);
     if (_controller->assumeOnlineUntil.isValid())
         atis += QString("<p><i>QuteScoop assumes from this information that this controller will be online until %1z</i></p>")
             .arg(_controller->assumeOnlineUntil.toString("HHmm"));
     lblAtis->setText(atis);
-    lblAtis->adjustSize(); // ensure auto-resize
+    // This does not seem to be necessary. Changing the content changes the size hint and triggers a window resize.
+    // lblAtis->adjustSize(); // ensure auto-resize
 
     gbAtis->setTitle(_controller->label.endsWith("_ATIS")? "ATIS" : "Controller info");
 
@@ -96,11 +97,11 @@ void ControllerDetails::refresh(Controller *newController) {
     buttonAddFriend->setDisabled(invalidID);
     pbAlias->setDisabled(invalidID);
 
-
-    // check if we know position
+    // enable if we know position
     buttonShowOnMap->setDisabled(qFuzzyIsNull(_controller->lat) && qFuzzyIsNull(_controller->lon));
 
-    adjustSize();
+    // @see https://github.com/qutescoop/qutescoop/issues/124
+    // adjustSize();
 }
 
 void ControllerDetails::on_buttonAddFriend_clicked() {

--- a/src/ControllerDetails.ui
+++ b/src/ControllerDetails.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>326</width>
-    <height>310</height>
+    <width>286</width>
+    <height>278</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,7 +20,10 @@
    <iconset resource="Resources.qrc">
     <normaloff>:/icons/qutescoop.png</normaloff>:/icons/qutescoop.png</iconset>
   </property>
-  <layout class="QVBoxLayout">
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="_2">
    <property name="margin" stdset="0">
     <number>6</number>
    </property>

--- a/src/ControllerDetails.ui
+++ b/src/ControllerDetails.ui
@@ -10,6 +10,12 @@
     <height>310</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowIcon">
    <iconset resource="Resources.qrc">
     <normaloff>:/icons/qutescoop.png</normaloff>:/icons/qutescoop.png</iconset>

--- a/src/ControllerDetails.ui
+++ b/src/ControllerDetails.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>326</width>
-    <height>304</height>
+    <height>310</height>
    </rect>
   </property>
   <property name="windowIcon">
    <iconset resource="Resources.qrc">
     <normaloff>:/icons/qutescoop.png</normaloff>:/icons/qutescoop.png</iconset>
   </property>
-  <layout class="QVBoxLayout" stretch="0,1,0">
+  <layout class="QVBoxLayout">
    <property name="margin" stdset="0">
     <number>6</number>
    </property>

--- a/src/ControllerDetails.ui
+++ b/src/ControllerDetails.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>286</width>
-    <height>409</height>
+    <width>326</width>
+    <height>304</height>
    </rect>
   </property>
   <property name="windowIcon">
@@ -25,7 +25,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
@@ -125,12 +125,6 @@
       </property>
       <item>
        <widget class="QLabel" name="lblAtis">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="text">
          <string>ATIS</string>
         </property>

--- a/src/PilotDetails.cpp
+++ b/src/PilotDetails.cpp
@@ -126,7 +126,8 @@ void PilotDetails::refresh(Pilot *pilot) {
         lblPlotStatus->setText(QString("waypoints (calculated): <code>%1</code>").arg(_pilot->routeWaypointsStr()));
     lblPlotStatus->setVisible(_pilot->showDepDestLine || plottedAirports);
 
-    adjustSize();
+    // @see https://github.com/qutescoop/qutescoop/issues/124
+    // adjustSize();
 }
 
 void PilotDetails::on_buttonDest_clicked() {

--- a/src/PilotDetails.ui
+++ b/src/PilotDetails.ui
@@ -127,6 +127,12 @@
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
          </spacer>
         </item>
        </layout>
@@ -221,6 +227,12 @@
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
           </property>
          </spacer>
         </item>
@@ -552,12 +564,6 @@ delay: difference between planned and calculated ETA</string>
       </item>
       <item row="4" column="1" colspan="3">
        <widget class="QLabel" name="lblRoute">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="mouseTracking">
          <bool>true</bool>
         </property>
@@ -587,6 +593,12 @@ delay: difference between planned and calculated ETA</string>
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
           </property>
          </spacer>
         </item>
@@ -636,12 +648,6 @@ route</string>
       </item>
       <item row="6" column="1" colspan="3">
        <widget class="QLabel" name="lblRemarks">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="text">
          <string>&lt;code&gt;PBN/A1B1D1O1S2 NAV/RNVD1E2A1 DOF/220222 REG/DABVM EET/EDUU0013 LOVV0029 LJLA0039 LDZO0044 LQSB0054 LYBA0109 BKPR0117 LWSS0124 LGGG0133 LTBB0212 LGGG0217 LCCC0235 HECC0255 OJAC0325 OEJD0334 OBBB0447 OMAE0508 RMK/TCAS /V/&lt;/code&gt;</string>
         </property>

--- a/src/PilotDetails.ui
+++ b/src/PilotDetails.ui
@@ -14,7 +14,10 @@
    <iconset resource="Resources.qrc">
     <normaloff>:/icons/qutescoop.png</normaloff>:/icons/qutescoop.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="_2">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">

--- a/src/PilotDetails.ui
+++ b/src/PilotDetails.ui
@@ -14,7 +14,7 @@
    <iconset resource="Resources.qrc">
     <normaloff>:/icons/qutescoop.png</normaloff>:/icons/qutescoop.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">


### PR DESCRIPTION
This fixes dialog sizes changing by themselves, even on consecutive
`refresh()`s with the same data which has lead to bad UX.

Dialogs will still try to grow in size when but not that aggressively.

On the other hand the dialog size might now not accomodate for all the
data shown. So users might occasionally have to resize the dialog
themselves to see long routes, ATISes or flight plan remarks.

Resolves: #124
