### PR TITLE
Disable the adding of an alias for an invalid ID

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -106,3 +106,7 @@ const QString Client::name() const
 {
     return m_name;
 }
+
+bool Client::hasValidID() const {
+    return Client::isValidID(userId);
+}

--- a/src/Client.h
+++ b/src/Client.h
@@ -37,6 +37,11 @@ class Client: public MapObject {
 
         int rating;
 
+        static bool isValidID(const QString id) {
+            return !id.isEmpty() && id.toInt() >= 800000;
+        };
+        bool hasValidID() const;
+
     protected:
         QString m_name;
 };

--- a/src/ControllerDetails.cpp
+++ b/src/ControllerDetails.cpp
@@ -7,6 +7,7 @@
 #include "Window.h"
 #include "Settings.h"
 #include "Whazzup.h"
+#include "helpers.h"
 
 //singleton instance
 ControllerDetails *controllerDetails = 0;
@@ -91,7 +92,10 @@ void ControllerDetails::refresh(Controller *newController) {
         buttonAddFriend->setText("add &friend");
 
     // check if we know UserId
-    buttonAddFriend->setDisabled(_controller->userId.isEmpty());
+    bool invalidID = !isValidID(_controller->userId);
+    buttonAddFriend->setDisabled(invalidID);
+    pbAlias->setDisabled(invalidID);
+
 
     // check if we know position
     buttonShowOnMap->setDisabled(qFuzzyIsNull(_controller->lat) && qFuzzyIsNull(_controller->lon));

--- a/src/ControllerDetails.cpp
+++ b/src/ControllerDetails.cpp
@@ -92,7 +92,7 @@ void ControllerDetails::refresh(Controller *newController) {
         buttonAddFriend->setText("add &friend");
 
     // check if we know UserId
-    bool invalidID = !isValidID(_controller->userId);
+    bool invalidID = !(_controller->hasValidID());
     buttonAddFriend->setDisabled(invalidID);
     pbAlias->setDisabled(invalidID);
 

--- a/src/PilotDetails.cpp
+++ b/src/PilotDetails.cpp
@@ -101,7 +101,7 @@ void PilotDetails::refresh(Pilot *pilot) {
     lblRemarks->setText(QString("<code>%1</code>").arg(_pilot->planRemarks));
 
     // check if we know userId
-    bool invalidID = !isValidID(_pilot->userId);
+    bool invalidID = !(_pilot->hasValidID());
     buttonAddFriend->setDisabled(invalidID);
     pbAlias->setDisabled(invalidID);
     buttonAddFriend->setText(_pilot->isFriend()? "remove &friend": "add &friend");

--- a/src/PilotDetails.cpp
+++ b/src/PilotDetails.cpp
@@ -101,7 +101,9 @@ void PilotDetails::refresh(Pilot *pilot) {
     lblRemarks->setText(QString("<code>%1</code>").arg(_pilot->planRemarks));
 
     // check if we know userId
-    buttonAddFriend->setDisabled(_pilot->userId.isEmpty());
+    bool invalidID = !isValidID(_controller->userId);
+    buttonAddFriend->setDisabled(invalidID);
+    pbAlias->setDisabled(invalidID);
     buttonAddFriend->setText(_pilot->isFriend()? "remove &friend": "add &friend");
 
     // check if we know position

--- a/src/PilotDetails.cpp
+++ b/src/PilotDetails.cpp
@@ -101,7 +101,7 @@ void PilotDetails::refresh(Pilot *pilot) {
     lblRemarks->setText(QString("<code>%1</code>").arg(_pilot->planRemarks));
 
     // check if we know userId
-    bool invalidID = !isValidID(_controller->userId);
+    bool invalidID = !isValidID(_pilot->userId);
     buttonAddFriend->setDisabled(invalidID);
     pbAlias->setDisabled(invalidID);
     buttonAddFriend->setText(_pilot->isFriend()? "remove &friend": "add &friend");

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -10,7 +10,7 @@
 #include "PilotDetails.h"
 #include "ControllerDetails.h"
 #include "AirportDetails.h"
-#include "helpers.h"
+#include "Client.h"
 
 QSettings *settingsInstance = 0;
 QSettings* Settings::instance() {
@@ -37,7 +37,7 @@ QSettings* Settings::instance() {
                 foreach(auto key, keys) {
                     if(key.startsWith("alias_")) {
                         QString id = key.mid(6);
-                        if(!isValidID(id)) {
+                        if(!Client::isValidID(id)) {
                             settingsInstance->remove(key);
                             qDebug() << "Found an alias for (invalid) client " << id << " and removed it. For more information see https://github.com/qutescoop/qutescoop/issues/130";
                         }
@@ -46,7 +46,7 @@ QSettings* Settings::instance() {
                 settingsInstance->endGroup();
                 QStringList friendList = settingsInstance->value("friends/friendList", QStringList()).toStringList();
                 foreach(auto friendID, friendList) {
-                    if(!isValidID(friendID)) {
+                    if(!Client::isValidID(friendID)) {
                         friendList.removeAt(friendList.indexOf(friendID));
                         qDebug() << "Found a friend list entry for (invalid) client " << friendID << " and removed it. For more information see https://github.com/qutescoop/qutescoop/issues/130";
                     }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -10,22 +10,51 @@
 #include "PilotDetails.h"
 #include "ControllerDetails.h"
 #include "AirportDetails.h"
+#include "helpers.h"
 
 QSettings *settingsInstance = 0;
 QSettings* Settings::instance() {
     if(settingsInstance == 0) {
         settingsInstance = new QSettings();
 
-        const int requiredSettingsVersion = 1;
-        const int currentSettingsVersion = settingsInstance->value("settings/version", 0).toInt();
+        const int requiredSettingsVersion = 2;
+        int currentSettingsVersion = settingsInstance->value("settings/version", 0).toInt();
         if (currentSettingsVersion < requiredSettingsVersion) {
-            if((settingsInstance->value("download/network", 0).toInt() == 1)
-            && (settingsInstance->value("download/statusLocation", "").toString() == "http://status.vatsim.net/")) {
-                settingsInstance->setValue("download/network", 0);
-                qDebug() << "Found a user defined network, but VATSIM status location. Migrated.";
+            if(currentSettingsVersion < 1) {
+                qDebug() << "Starting migration 0 -> 1";
+                if((settingsInstance->value("download/network", 0).toInt() == 1)
+                && (settingsInstance->value("download/statusLocation", "").toString() == "http://status.vatsim.net/")) {
+                    settingsInstance->setValue("download/network", 0);
+                    qDebug() << "Found a user defined network, but VATSIM status location. Migrated.";
+                }
+                settingsInstance->remove("download/statusLocation");
+                currentSettingsVersion = 1;
             }
-            settingsInstance->remove("download/statusLocation");
-            settingsInstance->setValue("settings/version", requiredSettingsVersion);
+            if(currentSettingsVersion < 2) {
+                qDebug() << "Starting migration 1 -> 2";
+                settingsInstance->beginGroup("clients");
+                QStringList keys = settingsInstance->childKeys();
+                foreach(auto key, keys) {
+                    if(key.startsWith("alias_")) {
+                        QString id = key.mid(6);
+                        if(!isValidID(id)) {
+                            settingsInstance->remove(key);
+                            qDebug() << "Found an alias for (invalid) client " << id << " and removed it. For more information see https://github.com/qutescoop/qutescoop/issues/130";
+                        }
+                    }
+                }
+                settingsInstance->endGroup();
+                QStringList friendList = settingsInstance->value("friends/friendList", QStringList()).toStringList();
+                foreach(auto friendID, friendList) {
+                    if(!isValidID(friendID)) {
+                        friendList.removeAt(friendList.indexOf(friendID));
+                        qDebug() << "Found a friend list entry for (invalid) client " << friendID << " and removed it. For more information see https://github.com/qutescoop/qutescoop/issues/130";
+                    }
+                }
+                settingsInstance->setValue("friends/friendList", friendList);
+                currentSettingsVersion = 2;
+            }
+            settingsInstance->setValue("settings/version", currentSettingsVersion);
         }
     }
     return settingsInstance;

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -21,6 +21,12 @@ static float lerp(float v0, float v1, float t) {
     return v0 + t * (v1 - v0);
 }
 
+static bool isValidID(QString id) {
+    if(id.isEmpty()) return false;
+    int iid = id.toInt();
+    return iid >= 800000;
+}
+
 /* mathematical constants */
 const double Pi180 = M_PI / 180.;
 

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -21,12 +21,6 @@ static float lerp(float v0, float v1, float t) {
     return v0 + t * (v1 - v0);
 }
 
-static bool isValidID(QString id) {
-    if(id.isEmpty()) return false;
-    int iid = id.toInt();
-    return iid >= 800000;
-}
-
 /* mathematical constants */
 const double Pi180 = M_PI / 180.;
 


### PR DESCRIPTION
This is a partial fix for #130, it disables the "Add friend" and "Alias" buttons in case the VATSIM ID of the client is below `800000`.