### PR TITLE
[TASK] cleanup unused Controller::timeLastAtisReceived

### DIFF
--- a/src/BookedController.cpp
+++ b/src/BookedController.cpp
@@ -89,7 +89,6 @@ BookedController::BookedController(const QJsonObject& json, const WhazzupData* w
     //some unapplicable data for a booked controller, but we might need it once to cast BookedController -> Controller
     frequency = "";
     atisMessage = "";
-    timeLastAtisReceived = QDateTime();
     server = "";
 }
 

--- a/src/BookedController.h
+++ b/src/BookedController.h
@@ -35,7 +35,6 @@ class BookedController: public Client {
 
         QString frequency, atisMessage;
         int facilityType, visualRange;
-        QDateTime timeLastAtisReceived;
 
         // Booking values
         QString link, bookingInfoStr, timeFrom, timeTo, date, eventLink;

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -23,7 +23,6 @@ Controller::Controller(const QJsonObject& json, const WhazzupData* whazzup):
     if(label.right(4) == "_FSS") facilityType = 7; // workaround as VATSIM reports 1 for _FSS
 
     visualRange = json["visual_range"].toInt();
-    timeLastAtisReceived = QDateTime::fromString(json["last_updated"].toString(), Qt::ISODate);
 
     atisMessage = "";
     if(json.contains("text_atis") && json["text_atis"].isArray()) {

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -41,7 +41,7 @@ class Controller: public Client {
 
         QString frequency, atisMessage;
         int facilityType, visualRange;
-        QDateTime timeLastAtisReceived, assumeOnlineUntil;
+        QDateTime assumeOnlineUntil;
 
         Sector *sector;
 

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -213,8 +213,6 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data):
             // not applicable:
             //frequency = getField(stringList, 4);
             //visualRange = getField(stringList, 19).toInt();
-            //timeLastAtisReceived = QDateTime::fromString(getField(stringList, 36), "yyyyMMddHHmmss");
-            //protrevision = getField(stringList, 15).toInt();
             //rating = getField(stringList, 16).toInt();
 
             controllers[bc->label] = new Controller(controllerObject, this);


### PR DESCRIPTION
We have never made use of that and we do not need to track when a
controller info has changed.
