### PR TITLE
[BUGFIX] preserve IDs of booked controllers

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -39,7 +39,7 @@ QString Client::displayName(bool withLink) const {
     if(!rank().isEmpty())
         result += " (" + rank() + ")";
 
-    if(withLink && !userId.isEmpty()) {
+    if(withLink && hasValidID()) {
         QString link = Whazzup::instance()->userUrl(userId);
         if(link.isEmpty())
             return result;

--- a/src/Whazzup.cpp
+++ b/src/Whazzup.cpp
@@ -326,7 +326,7 @@ void Whazzup::processBookings() {
 
 
 QString Whazzup::userUrl(const QString& id) const {
-    if(_user0Url.isEmpty())
+    if(_user0Url.isEmpty() || !Client::isValidID(id))
         return QString();
     return _user0Url + "?id=" + id;
 }

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -192,6 +192,7 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data):
 
             controllerObject["callsign"] = bc->label;
             controllerObject["name"] = bc->realName();
+            controllerObject["cid"] = bc->userId.toInt();
             controllerObject["facility"] = bc->facilityType;
 
             //atisMessage = getField(stringList, 35);


### PR DESCRIPTION
Due to a missing type conversion we lost VATSIM IDs of booked
controllers when they were becoming "real" controllers in Time Warp
mode.

This also adds some checks to avoid showing VATSIM statistics center
links for clients where we actually do not have an ID.

Nota bene: Not all booked controller records actually contain an ID.
Cross-check with http://vatbook.euroutepro.com/servinfo.asp when you
wonder why a certain controller does not have the "add friend"/"add
alias"/VATSIM statistics functionality.

Resolves: #130
