### PR TITLE
Allow multiple ATISes per airport

### DIFF
--- a/src/Airport.cpp
+++ b/src/Airport.cpp
@@ -45,6 +45,7 @@ void Airport::resetWhazzupStatus() {
     approaches.clear();
     grounds.clear();
     deliveries.clear();
+    atises.clear();
     arrivals.clear();
     departures.clear();
     numFilteredArrivals = 0;
@@ -276,6 +277,10 @@ void Airport::addDelivery(Controller* client) {
     active = true;
 }
 
+void Airport::addAtis(Controller* client) {
+    atises.insert(client);
+    active = true;
+}
 
 void Airport::showDetailsDialog() {
     AirportDetails *infoDialog = AirportDetails::instance();
@@ -287,7 +292,7 @@ void Airport::showDetailsDialog() {
 }
 
 QSet<Controller*> Airport::allControllers() const {
-    return approaches + towers + grounds + deliveries;
+    return approaches + towers + grounds + deliveries + atises;
 }
 
 bool Airport::matches(const QRegExp& regex) const {

--- a/src/Airport.h
+++ b/src/Airport.h
@@ -31,7 +31,7 @@ class Airport: public MapObject {
 
         bool active;
 
-        QSet<Controller*> approaches, towers, grounds, deliveries;
+        QSet<Controller*> approaches, towers, grounds, deliveries, atises;
         QSet<Pilot*> arrivals, departures;
         QSet<Controller*> allControllers() const;
 
@@ -44,6 +44,7 @@ class Airport: public MapObject {
         void addTower(Controller *client);
         void addGround(Controller *client);
         void addDelivery(Controller *client);
+        void addAtis(Controller *client);
 
         QString name, city, countryCode;
 

--- a/src/AirportDetails.cpp
+++ b/src/AirportDetails.cpp
@@ -138,12 +138,6 @@ void AirportDetails::refresh(Airport* newAirport) {
 
     QSet<Controller*> atcContent = _airport->allControllers() + checkSectors();
 
-    // ATIS
-    Controller* atis = Whazzup::instance()->whazzupData().controllers[_airport->label + "_ATIS"];
-    if (atis != 0) {
-        atcContent.insert(atis);
-    }
-
     // non-ATC
     if(cbOtherAtc->isChecked()) {
         foreach(Controller *c, Whazzup::instance()->whazzupData().controllers) {

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -46,7 +46,7 @@ Controller::Controller(const QJsonObject& json, const WhazzupData* whazzup):
         }
     }
 
-    QString icao = this->getCenter();
+    QString icao = this->getSectorName();
     if (!icao.isEmpty()) {
         while(!NavData::instance()->sectors.contains(icao) && !icao.isEmpty()) {
             int p = icao.lastIndexOf('_');
@@ -95,7 +95,7 @@ QString Controller::facilityString() const {
     return QString();
 }
 
-QString Controller::getCenter() const{
+QString Controller::getSectorName() const{
     if(!isATC())
         return QString();
     QStringList list = label.split('_');
@@ -158,6 +158,18 @@ QString Controller::getDelivery() const {
         return QString();
     QStringList list = label.split('_');
     if(list.last().startsWith("DEL")) {
+        if(list.first().length() == 3)
+            return "K" + list.first(); // VATSIMmers don't think ICAO codes are cool
+        return list.first();
+    }
+    return QString();
+}
+
+QString Controller::getAtis() const {
+    if(!isATC())
+        return QString();
+    QStringList list = label.split('_');
+    if(list.last().startsWith("ATIS")) {
         if(list.first().length() == 3)
             return "K" + list.first(); // VATSIMmers don't think ICAO codes are cool
         return list.first();

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -31,11 +31,12 @@ class Controller: public Client {
         bool isATC() const; // facilityType = 1 is reported for FSS stations (at least from VATSIM)
         QString rank() const;
 
-        QString getCenter() const;
+        QString getSectorName() const;
         QString getApproach() const;
         QString getTower() const;
         QString getGround() const;
         QString getDelivery() const;
+        QString getAtis() const;
 
         Airport *airport() const;
 

--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -1334,7 +1334,7 @@ void GLWidget::renderLabels() {
     QList<MapObject*> objects;
     // draw all CTR+FSS labels, also if sector unknown
     foreach(Controller *c, Whazzup::instance()->whazzupData().controllers)
-        if (!c->getCenter().isNull())
+        if (!c->getSectorName().isNull())
             objects.append(c);
     renderLabels(objects, Settings::firFont(), _controllerLabelZoomTreshold,
                  Settings::firFontColor());

--- a/src/NavData.cpp
+++ b/src/NavData.cpp
@@ -181,6 +181,11 @@ void NavData::updateData(const WhazzupData& whazzupData) {
             airports[icao]->addDelivery(c);
             newActiveAirportsSet.insert(airports[icao]);
         }
+        icao = c->getAtis();
+        if(!icao.isNull() && airports.contains(icao)) {
+            airports[icao]->addAtis(c);
+            newActiveAirportsSet.insert(airports[icao]);
+        }
     }
 
     // new method with MultiMap. Tests show: 450ms vs. 3800ms for 800 pilots :)

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -197,8 +197,10 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data):
 
             //atisMessage = getField(stringList, 35);
             QJsonArray atisLines;
-            atisLines.append(QString("BOOKED from %1, online until %2").arg(bc->starts().toString("HHmm'z'"))
-                                                                .arg(bc->ends().toString("HHmm'z'")));
+            atisLines.append(
+                  QString("BOOKED from %1, online until %2")
+                    .arg(bc->starts().toString("HHmm'z'"), bc->ends().toString("HHmm'z'"))
+            );
             atisLines.append(bc->bookingInfoStr);
             controllerObject["text_atis"] = atisLines;
 


### PR DESCRIPTION
This is primarily targeted at allowing ATISes that are not of the form
`<airport>_ATIS`.

This should also properly "activate" an airport if the ATIS is the only
"ATC" at that airport and if there are no pilot movements.

Fixes: #148
