### PR TITLE
[BUGFIX] fix issues with route resolver

### DIFF
--- a/src/Airac.cpp
+++ b/src/Airac.cpp
@@ -89,7 +89,7 @@ void Airac::readFixes(const QString& directory) {
 
         fixes[wp->label].insert(wp);
     }
-    qDebug() << "Read fixes from\t" << (directory + "/earth_fix.dat")
+    qDebug() << "Read fixes from" << (directory + "/earth_fix.dat")
              << "-" << fixes.size() << "imported";
 }
 
@@ -126,7 +126,7 @@ void Airac::readNavaids(const QString& directory) {
 
         navaids[nav->label].insert(nav);
     }
-    qDebug() << "Read navaids from\t" << (directory + "/earth_nav.dat")
+    qDebug() << "Read navaids from" << (directory + "/earth_nav.dat")
             << "-" << navaids.size() << "imported";
 }
 
@@ -151,7 +151,7 @@ void Airac::readAirways(const QString& directory) {
     while(!fr.atEnd()) {
         QString line = fr.nextLine().trimmed();
         // file format:
-        // ABDOR GM 11 VALBA GM 11 N 2 195 460 UZ801
+        // EXOLU VA 11 TAXUN VA 11 N 2  75 460 B342-N519-W14
         // https://developer.x-plane.com/article/navdata-in-x-plane-11/
 
         if(line.isEmpty())
@@ -162,9 +162,10 @@ void Airac::readAirways(const QString& directory) {
             break;
 
         QStringList list = line.split(' ', Qt::SkipEmptyParts);
-        // @todo: why is this check here?
-        if(list.size() < 10 || list.size() > 20)
+        if(list.size() != 11) {
+            qCritical() << "Airac::readAirways() not exactly 11 fields:" << list;
             continue;
+        }
 
         QString id = list[0];
         QString regionCode = list[1];
@@ -192,39 +193,10 @@ void Airac::readAirways(const QString& directory) {
             continue;
         }
 
-        Airway::Type type = (Airway::Type)list[7].toInt(&ok);
-        if(!ok) {
-            qCritical() << "Airac::readAirways() unable to parse airwaytype (int):" << list;
-            continue;
-        }
-
-        int base = list[8].toInt(&ok);
-        if(!ok) {
-            qCritical() << "Airac::readAirways() unable to parse base (int):" << list;
-            continue;
-        }
-
-        int top = list[9].toInt(&ok);
-        if(!ok) {
-            qCritical() << "Airac::readAirways() unable to parse top (int):" << list;
-            continue;
-        }
-
         QStringList names;
-        if(list.size() > 11) {
-            //handle airways with spaces (!) in the name
-            QString glue;
-            for(int i = 10; i < list.size(); i++) {
-                if(i > 10)
-                    glue += " ";
-                glue += list[i];
-            }
-            names = glue.split('-', Qt::SkipEmptyParts);
-        } else
-            names = list[10].split('-', Qt::SkipEmptyParts);
-
+        names = list[10].split('-', Qt::SkipEmptyParts);
         for(int i = 0; i < names.size(); i++) {
-            addAirwaySegment(start, end, type, base, top, names[i]);
+            addAirwaySegment(start, end, names[i]);
             segments++;
         }
     }
@@ -237,7 +209,7 @@ void Airac::readAirways(const QString& directory) {
         list = sorted;
     }
 
-    qDebug() << "Read airways from\t" << (directory + "/earth_awy.dat")
+    qDebug() << "Read airways from" << (directory + "/earth_awy.dat")
             << "-" << airways.size() << "airways," << segments << "segments imported and sorted";
 }
 
@@ -258,11 +230,10 @@ Waypoint* Airac::waypoint(const QString &id, const QString &regionCode, const in
 }
 
 /**
-  find a waypoint that is near the given location @param lat, @param lon with
-  the given maximum distance @maxDist.
+  find a waypoint that is near the given location with the given maximum distance.
   @returns 0 if none found
 **/
-Waypoint* Airac::waypointNearby(const QString& id, double lat, double lon, double maxDist) const {
+Waypoint* Airac::waypointNearby(const QString& id, double lat, double lon, double maxDist = 20000.) const {
     // @todo clean this up
     // @todo add "virtual" fixes (ARINC424) to our nav database upfront instead of returning them
     // here dynamically (without adding them), which leads to duplicates
@@ -307,56 +278,55 @@ Waypoint* Airac::waypointNearby(const QString& id, double lat, double lon, doubl
             double d = NavData::distance(lat, lon, arincP->first, arincP->second);
             if ((d < minDist) && (d < maxDist)) {
                 result = new Waypoint(id, arincP->first, arincP->second);
-                minDist = d;
             }
         } else if (slash.exactMatch(id)) { // slash-style: 35/30
-            double wLat = slash.capturedTexts()[1].toDouble();
-            double wLon = slash.capturedTexts()[2].toDouble();
+            auto capturedTexts = slash.capturedTexts();
+            double wLat = capturedTexts[1].toDouble();
+            double wLon = capturedTexts[2].toDouble();
             double d = NavData::distance(lat, lon, wLat, wLon);
             if ((d < minDist) && (d < maxDist)) {
                 result = new Waypoint(NavData::toArinc(wLat, wLon), wLat, wLon);
-                minDist = d;
             }
         } else if (wildGuess.exactMatch(id)) { // N53W170
-            double wLat = wildGuess.capturedTexts()[2].toDouble();
-            double wLon = wildGuess.capturedTexts()[4].toDouble();
-            if ((wildGuess.capturedTexts()[1] == "S") ||
-                (wildGuess.capturedTexts()[3] == "S"))
+            auto capturedTexts = wildGuess.capturedTexts();
+            double wLat = capturedTexts[2].toDouble();
+            double wLon = capturedTexts[4].toDouble();
+            if ((capturedTexts[1] == "S") ||
+                (capturedTexts[3] == "S"))
                 wLat = -wLat;
-            if ((wildGuess.capturedTexts()[3] == "W") ||
-                (wildGuess.capturedTexts()[5] == "W"))
+            if ((capturedTexts[3] == "W") ||
+                (capturedTexts[5] == "W"))
                 wLon = -wLon;
             double d = NavData::distance(lat, lon, wLat, wLon);
             if ((d < minDist) && (d < maxDist)) {
                 result = new Waypoint(NavData::toArinc(wLat, wLon), wLat, wLon);
-                minDist = d;
             }
         } else if (idiotFormat.exactMatch(id)) { // 3000N 02000W (space removed by resolveFlightplan)
-            double wLat = idiotFormat.capturedTexts()[1].toDouble();
-            double wLon = idiotFormat.capturedTexts()[3].toDouble();
+            auto capturedTexts = idiotFormat.capturedTexts();
+            double wLat = capturedTexts[1].toDouble();
+            double wLon = capturedTexts[3].toDouble();
             while (wLat > 90)
                 wLat /= 10.;
             while (wLon > 180)
                 wLon /= 10.;
-            if (idiotFormat.capturedTexts()[2] == "S")
+            if (capturedTexts[2] == "S")
                 wLat = -wLat;
-            if (idiotFormat.capturedTexts()[4] == "W")
+            if (capturedTexts[4] == "W")
                 wLon = -wLon;
             double d = NavData::distance(lat, lon, wLat, wLon);
             if ((d < minDist) && (d < maxDist)) {
                 result = new Waypoint(NavData::toArinc(wLat, wLon), wLat, wLon);
-                minDist = d;
             }
         }
     }
     return result;
 }
 
-Airway* Airac::airway(const QString& name, Airway::Type type, int base, int top) {
+Airway* Airac::airway(const QString& name) {
     foreach(Airway *a, airways[name])
-        if(a->type == type)
-            return a;
-    Airway* awy = new Airway(name, type, base, top);
+        return a;
+
+    Airway* awy = new Airway(name);
     airways[name].append(awy);
     return awy;
 }
@@ -385,8 +355,8 @@ Airway* Airac::airwayNearby(const QString& name, double lat, double lon) const {
     return result;
 }
 
-void Airac::addAirwaySegment(Waypoint *from, Waypoint *to, Airway::Type type, int base, int top, const QString& name) {
-    Airway *awy = airway(name, type, base, top);
+void Airac::addAirwaySegment(Waypoint *from, Waypoint *to, const QString& name) {
+    Airway *awy = airway(name);
     awy->addSegment(from, to);
 }
 
@@ -396,44 +366,51 @@ void Airac::addAirwaySegment(Waypoint *from, Waypoint *to, Airway::Type type, in
 * airway. lat/lon is being used as a hint and should be the position of the
 * departure airport.
 *
-* Input format can be:
-* 1. FIX - FIX - FIX
-* 2. FIX - Airway - FIX - Airway - FIX
-*
 * Unknown fixes and/or airways will be ignored.
 **/
 QList<Waypoint*> Airac::resolveFlightplan(QStringList plan, double lat, double lon) const {
     //qDebug() << "Airac::resolveFlightPlan()" << plan;
     QList<Waypoint*> result;
-    if(plan.isEmpty()) return result;
     Waypoint* currPoint = 0;
+    Airway* awy = 0;
     bool wantAirway = false;
     while (!plan.isEmpty()) {
         QString id = plan.takeFirst();
-        Airway *awy = 0;
-        if (wantAirway)
+
+        // remove everything following an invalid character (e.g. "/N320F240")
+        id = id.replace(QRegExp("[^A-Za-z0-9].*$"), "");
+
+        if (wantAirway) {
             awy = airwayNearby(id, lat, lon);
-        if (awy != 0 && !plan.isEmpty()) {
+        }
+        if (wantAirway && (awy != 0) && !plan.isEmpty()) {
             wantAirway = false;
             // have airway - next should be a waypoint
             QString endId = plan.first();
             Waypoint* wp = waypointNearby(endId, lat, lon);
             if(wp != 0) {
-                if (currPoint != 0)
-                    result += awy->expand(currPoint->label, wp->label);
+                if (currPoint != 0) {
+                    auto _expand = awy->expand(currPoint->label, wp->label);
+                    result.append(_expand);
+                }
                 currPoint = wp;
                 lat = wp->lat;
                 lon = wp->lon;
                 plan.removeFirst();
                 wantAirway = true;
-                continue;
             }
         } else if (awy == 0) {
-            if (!plan.isEmpty()) // joining with the next point for idiot style..
-                if (QRegExp("\\d{2,4}[NS]").exactMatch(id) && //.. 30(00)N (0)50(00)W
-                    QRegExp("(\\d{2,3}|\\d{5})[EW]").exactMatch(plan.first()))
-                                    // but preserving correct ARINC style (\\d{4}[EW])
+            if (!plan.isEmpty()) {// joining with the next point for idiot style..
+                if (
+                    QRegExp("\\d{2,4}[NS]").exactMatch(id) //.. 30(00)N (0)50(00)W
+                    && QRegExp("(\\d{2,3}|\\d{5})[EW]").exactMatch(plan.first())
+                          // but preserving correct ARINC style (\\d{4}[EW])
+                ) {
+
                     id += plan.takeFirst();
+                }
+            }
+
             Waypoint* wp = waypointNearby(id, lat, lon);
             if(wp != 0) {
                 result.append(wp);
@@ -444,9 +421,6 @@ QList<Waypoint*> Airac::resolveFlightplan(QStringList plan, double lat, double l
             wantAirway = (wp != 0);
         }
     }
-//    QString debugStr;
-//    foreach (Waypoint *p, result)
-//        debugStr += p->label + " ";
-//    qDebug() << "Airac::resolveFlightPlan() -- finished:" << debugStr;
+
     return result;
 }

--- a/src/Airac.cpp
+++ b/src/Airac.cpp
@@ -375,10 +375,7 @@ QList<Waypoint*> Airac::resolveFlightplan(QStringList plan, double lat, double l
     Airway* awy = 0;
     bool wantAirway = false;
     while (!plan.isEmpty()) {
-        QString id = plan.takeFirst();
-
-        // remove everything following an invalid character (e.g. "/N320F240")
-        id = id.replace(QRegExp("[^A-Za-z0-9].*$"), "");
+        QString id = fpTokenToWaypoint(plan.takeFirst());
 
         if (wantAirway) {
             awy = airwayNearby(id, lat, lon);
@@ -386,7 +383,7 @@ QList<Waypoint*> Airac::resolveFlightplan(QStringList plan, double lat, double l
         if (wantAirway && (awy != 0) && !plan.isEmpty()) {
             wantAirway = false;
             // have airway - next should be a waypoint
-            QString endId = plan.first();
+            QString endId = fpTokenToWaypoint(plan.first());
             Waypoint* wp = waypointNearby(endId, lat, lon);
             if(wp != 0) {
                 if (currPoint != 0) {
@@ -407,7 +404,7 @@ QList<Waypoint*> Airac::resolveFlightplan(QStringList plan, double lat, double l
                           // but preserving correct ARINC style (\\d{4}[EW])
                 ) {
 
-                    id += plan.takeFirst();
+                    id += fpTokenToWaypoint(plan.takeFirst());
                 }
             }
 
@@ -423,4 +420,10 @@ QList<Waypoint*> Airac::resolveFlightplan(QStringList plan, double lat, double l
     }
 
     return result;
+}
+
+QString Airac::fpTokenToWaypoint(QString token) const
+{
+  // remove everything following an invalid character (e.g. "/N320F240")
+  return token.replace(QRegExp("[^A-Za-z0-9].*$"), "");
 }

--- a/src/Airac.h
+++ b/src/Airac.h
@@ -19,10 +19,9 @@ class Airac : public QObject {
         virtual ~Airac();
 
         Waypoint* waypoint(const QString &id, const QString &regionCode, const int &type) const;
-        Waypoint* waypointNearby(const QString &id, double lat, double lon,
-                           double maxDist = 2000.0) const;
+        Waypoint* waypointNearby(const QString &id, double lat, double lon, double maxDist) const;
 
-        Airway* airway(const QString& name, Airway::Type type, int base, int top);
+        Airway* airway(const QString& name);
         Airway* airwayNearby(const QString& name, double lat, double lon) const;
 
         QList<Waypoint*> resolveFlightplan(QStringList plan, double lat, double lon) const;
@@ -40,10 +39,7 @@ class Airac : public QObject {
         void readFixes(const QString &directory);
         void readNavaids(const QString &directory);
         void readAirways(const QString &directory);
-        void addAirwaySegment(Waypoint* from, Waypoint* to, Airway::Type type,
-                              int base, int top, const QString &name);
-
-        Airway* airwayNearby(const QString& name, Airway::Type type, int base, int top);
+        void addAirwaySegment(Waypoint* from, Waypoint* to, const QString &name);
 };
 
 #endif /* AIRAC_H_ */

--- a/src/Airac.h
+++ b/src/Airac.h
@@ -40,6 +40,8 @@ class Airac : public QObject {
         void readNavaids(const QString &directory);
         void readAirways(const QString &directory);
         void addAirwaySegment(Waypoint* from, Waypoint* to, const QString &name);
+
+        QString fpTokenToWaypoint(QString token) const;
 };
 
 #endif /* AIRAC_H_ */

--- a/src/Airway.cpp
+++ b/src/Airway.cpp
@@ -16,18 +16,15 @@ bool Airway::Segment::operator==(const Airway::Segment& other) const {
 			(to == other.from || to == other.to);
 }
 
-Airway::Airway(const QString& name, Type type, int base, int top) {
+Airway::Airway(const QString& name) {
 	this->name = name;
-	this->type = type;
-	this->base = base;
-	this->top = top;
 }
 
 void Airway::addSegment(Waypoint* from, Waypoint* to) {
 	Segment newSegment(from, to);
 	// check if we already have this segment
 	for(int i = 0; i < _segments.size(); i++) {
-		if(_segments[i] == newSegment) {
+		if(_segments[i].from == newSegment.from && _segments[i].to == newSegment.to) {
 			return;
 		}
 	}
@@ -38,7 +35,7 @@ Airway* Airway::createFromSegments() {
 	if(_segments.isEmpty())
 		return 0;
 
-	Airway* result = new Airway(name, type, base, top);
+	Airway* result = new Airway(name);
 	Segment seg = _segments.first();
 	_segments.removeFirst();
 	result->_waypoints.append(seg.from);
@@ -94,16 +91,24 @@ QList<Airway*> Airway::sort() {
 		if(awy != 0)
 			result.append(awy);
 	} while(awy != 0);
-	return result;
+
+        return result;
 }
 
 int Airway::index(const QString& id) const {
-	for(int i = 0; i < _waypoints.size(); i++)
-		if(_waypoints[i]->label == id)
+	for(int i = 0; i < _waypoints.size(); i++) {
+		if(_waypoints[i]->label == id) {
 			return i;
+		}
+	}
 	return -1;
 }
 
+/**
+ * Returns a list of all fixes along this airway from start
+ * to end. The expanded list will not include the given start
+ * point, but will include the given end point.
+ */
 QList<Waypoint*> Airway::expand(const QString& startId, const QString& endId) const {
 	QList<Waypoint*> result;
 	int startIndex = index(startId);

--- a/src/Airway.h
+++ b/src/Airway.h
@@ -11,26 +11,15 @@
 
 class Airway {
     public:
-        enum Type {
-            LOW = 1,
-            HIGH = 2
-        };
-
-        Airway(const QString& name, Type type, int base, int top);
+        Airway(const QString& name);
         virtual ~Airway() {}
 
-        /**
-         * Returns a list of all fixes along this airway from start
-         * to end. The expanded list will not include the given start
-         * point, but will include the given end point.
-         */
+        QList<Waypoint*> waypoints() const { return _waypoints; };
         QList<Waypoint*> expand(const QString& startId, const QString& endId) const;
         Waypoint* closestPointTo(double lat, double lon) const;
         void addSegment(Waypoint* from, Waypoint* to);
         QList<Airway*> sort();
 
-        Type type;
-        int base, top;
         QString name;
 
     private:

--- a/src/Route.cpp
+++ b/src/Route.cpp
@@ -24,8 +24,7 @@ void Route::calculateWaypointsAndDistance() {
         return;
 
     QStringList list = route.split(' ', Qt::SkipEmptyParts);
-    waypoints = Airac::instance()->resolveFlightplan(
-            list, depAirport->lat, depAirport->lon);
+    waypoints = Airac::instance()->resolveFlightplan(list, depAirport->lat, depAirport->lon);
 
     Waypoint* depWp = new Waypoint(depAirport->label, depAirport->lat, depAirport->lon);
     waypoints.prepend(depWp);


### PR DESCRIPTION
Our data structure assumed that airways are either "high" or "low". That
was wrong - airway segments are either high or low.

This lead to missing waypoints on some airways.

Flight plan resolving could choke on tokens like OLBEN/N300F310 when it
was the final point of an airway segment.

Fixes: #27
