### PR TITLE
[FEATURE] match partial sector names

### DIFF
--- a/src/Controller.h
+++ b/src/Controller.h
@@ -7,7 +7,6 @@
 
 #include "Client.h"
 #include "WhazzupData.h"
-#include "ClientDetails.h"
 #include "Sector.h"
 #include "Airport.h"
 
@@ -28,15 +27,18 @@ class Controller: public Client {
         bool matches(const QRegExp& regex) const;
 
         bool isObserver() const;
-        bool isATC() const; // facilityType = 1 is reported for FSS stations (at least from VATSIM)
+        bool isATC() const;
         QString rank() const;
 
-        QString getSectorName() const;
-        QString getApproach() const;
-        QString getTower() const;
-        QString getGround() const;
-        QString getDelivery() const;
-        QString getAtis() const;
+        QStringList atcLabelTokens() const;
+
+        QString controllerSectorName() const;
+        bool isCtrFss() const;
+        bool isAppDep() const;
+        bool isTwr() const;
+        bool isGnd() const;
+        bool isDel() const;
+        bool isAtis() const;
 
         Airport *airport() const;
 
@@ -45,8 +47,9 @@ class Controller: public Client {
         QDateTime assumeOnlineUntil;
 
         Sector *sector;
-
-    private:
+protected:
+        QString specialAirportWorkarounds(const QString& rawAirport) const;
+private:
 };
 
 #endif /*CONTROLLER_H_*/

--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -1332,9 +1332,8 @@ void GLWidget::renderLabels() {
 
     // FIR labels
     QList<MapObject*> objects;
-    // draw all CTR+FSS labels, also if sector unknown
     foreach(Controller *c, Whazzup::instance()->whazzupData().controllers)
-        if (!c->getSectorName().isNull())
+        if (c->sector != 0)
             objects.append(c);
     renderLabels(objects, Settings::firFont(), _controllerLabelZoomTreshold,
                  Settings::firFontColor());

--- a/src/NavData.cpp
+++ b/src/NavData.cpp
@@ -161,37 +161,30 @@ void NavData::updateData(const WhazzupData& whazzupData) {
     }
 
     foreach(Controller *c, whazzupData.controllers) {
-        QString icao = c->getApproach();
-        if(!icao.isNull() && airports.contains(icao)) {
-            airports[icao]->addApproach(c);
-            newActiveAirportsSet.insert(airports[icao]);
-        }
-        icao = c->getTower();
-        if(!icao.isNull() && airports.contains(icao)) {
-            airports[icao]->addTower(c);
-            newActiveAirportsSet.insert(airports[icao]);
-        }
-        icao = c->getGround();
-        if(!icao.isNull() && airports.contains(icao)) {
-            airports[icao]->addGround(c);
-            newActiveAirportsSet.insert(airports[icao]);
-        }
-        icao = c->getDelivery();
-        if(!icao.isNull() && airports.contains(icao)) {
-            airports[icao]->addDelivery(c);
-            newActiveAirportsSet.insert(airports[icao]);
-        }
-        icao = c->getAtis();
-        if(!icao.isNull() && airports.contains(icao)) {
-            airports[icao]->addAtis(c);
-            newActiveAirportsSet.insert(airports[icao]);
-        }
+        auto _airport = c->airport();
+        if (_airport != 0) {
+            if(c->isAppDep()) {
+                _airport->addApproach(c);
+            }
+            if(c->isTwr()) {
+                _airport->addTower(c);
+            }
+            if(c->isGnd()) {
+                _airport->addGround(c);
+            }
+            if(c->isDel()) {
+                _airport->addDelivery(c);
+            }
+            if(c->isAtis()) {
+                _airport->addAtis(c);
+            }
+            newActiveAirportsSet.insert(_airport);
+        }  
     }
 
-    // new method with MultiMap. Tests show: 450ms vs. 3800ms for 800 pilots :)
     activeAirports.clear();
     foreach(Airport *a, newActiveAirportsSet) {
-        int congestion = a->numFilteredArrivals + a->numFilteredDepartures; // sort key
+        int congestion = a->numFilteredArrivals + a->numFilteredDepartures;
         activeAirports.insert(congestion, a);
     }
 


### PR DESCRIPTION
This matches any part of the controller login (from 2 letters upwards)
to a sector.

It deals with VATSIM inconsistencies.

It allows for example to show controller "LOVV-B_CTR", although we do
not know a sector "LOVV-B", but we know "LOVV".

It keeps EURW-N_FSS working (where we have a sector "EURW-N").

This also removes much redundant logic and navdata probing for airport
controllers which improves performance on Whazzup data updates.

Fixes: #159
