### PR TITLE
[FEATURE] Add more pilot information, show FLs

### DIFF
--- a/src/Pilot.h
+++ b/src/Pilot.h
@@ -5,8 +5,6 @@
 #ifndef PILOT_H_
 #define PILOT_H_
 
-#include "_pch.h"
-
 #include "Airport.h"
 #include "Client.h"
 #include "Waypoint.h"
@@ -17,6 +15,8 @@ class Airport;
 
 class Pilot: public Client {
     public:
+        static int altToFl(int alt_ft, int qnh_mb);
+
         enum FlightStatus {
             BOARDING, GROUND_DEP, DEPARTING, EN_ROUTE, ARRIVING,
             GROUND_ARR, BLOCKED, CRASHED, BUSH, PREFILED
@@ -56,16 +56,17 @@ class Pilot: public Client {
         QList<Waypoint*> routeWaypointsWithDepDest();
         void checkStatus(); // adjust label visibility from flight status
 
-        QString planAircraft, planTAS, planDep, planAlt, planDest,
+        QString planAircraft, planAircraftFaa, planAircraftFull,
+        planTAS, planDep, planAlt, planDest,
         planAltAirport, planRevision, planFlighttype, planDeptime,
-        transponder, planRemarks, planRoute, planActtime, airlineCode,
-        qnh_inHg, qnh_mb,
+        transponder, transponderAssigned, planRemarks, planRoute, planActtime, airlineCode,
         routeWaypointsPlanDepCache, routeWaypointsPlanDestCache,
         routeWaypointsPlanRouteCache;
         QDate dayOfFlight;
         int altitude, groundspeed, planEnroute_hrs, planEnroute_mins,
-        planFuel_hrs, planFuel_mins;
-        double trueHeading;
+        planFuel_hrs, planFuel_mins,
+        qnh_mb;
+        double trueHeading, qnh_inHg;
         bool showDepDestLine;
         QDateTime whazzupTime; // need some local reference to that
         QList<Waypoint*> routeWaypointsCache; // caching calculated routeWaypoints

--- a/src/PilotDetails.cpp
+++ b/src/PilotDetails.cpp
@@ -69,10 +69,27 @@ void PilotDetails::refresh(Pilot *pilot) {
 
     // Aircraft Information
     lblAircraft->setText(QString("%1").arg(_pilot->planAircraft));
+    lblAircraft->setToolTip(QString("%1 – FAA: %2").arg(_pilot->planAircraftFull, _pilot->planAircraftFaa));
+
     lblAirline->setText(NavData::instance()->airlineStr(_pilot->airlineCode));
-    lblAltitude->setText(QString("%1 ft").arg(_pilot->altitude));
+    if (_pilot->altitude < 10000) {
+        lblAltitude->setText(
+          QString("%1 ft").arg(_pilot->altitude));
+    } else {
+        lblAltitude->setText(
+          QString("FL %1").arg(Pilot::altToFl(_pilot->altitude, _pilot->qnh_mb))
+        );
+    }
+    lblAltitude->setToolTip(
+      QString("local QNH %2 inHg / %3 hPa")
+        .arg(_pilot->qnh_inHg)
+        .arg(_pilot->qnh_mb)
+    );
+
     lblGroundspeed->setText(QString("%1 kts").arg(_pilot->groundspeed));
+
     lblSquawk->setText(QString("%1").arg(_pilot->transponder));
+    lblSquawk->setToolTip(QString("assigned: %1").arg(_pilot->transponderAssigned));
 
     // flight status
     groupStatus->setTitle(QString("Status: %1").arg(_pilot->flightStatusShortString()));

--- a/src/PilotDetails.ui
+++ b/src/PilotDetails.ui
@@ -95,9 +95,6 @@
             <bold>true</bold>
            </font>
           </property>
-          <property name="toolTip">
-           <string>ICAO aircraft type</string>
-          </property>
           <property name="text">
            <string>A319</string>
           </property>
@@ -195,9 +192,6 @@
            <font>
             <bold>true</bold>
            </font>
-          </property>
-          <property name="toolTip">
-           <string>current altitude</string>
           </property>
           <property name="text">
            <string>28000 ft</string>


### PR DESCRIPTION
This shows flight levels for pilots > 10k ft.

It also adds some values that we previously have not used:
* assigned xpdr code
* ICAO and FAA aircraft types
* local QNH (for easier debugging of pressure level discrepancies in
  X-Plane 12 VATSIM clients)

These values are shown in tooltips in the pilot dialog on hover.

As a driveby it also fixes a potential crash in the flightplan altitude
display.
