### PR TITLE
[FEATURE] Link to aircraft performance on doc8643.com

### DIFF
--- a/src/PilotDetails.cpp
+++ b/src/PilotDetails.cpp
@@ -69,7 +69,9 @@ void PilotDetails::refresh(Pilot *pilot) {
     buttonShowOnMap->setEnabled(_pilot->lat != 0 || _pilot->lon != 0);
 
     // Aircraft Information
-    lblAircraft->setText(QString("%1").arg(_pilot->planAircraft));
+    lblAircraft->setText(
+        QString("<a href='https://doc8643.com/aircraft/%1'>%1</a>").arg(_pilot->planAircraft)
+    );
     lblAircraft->setToolTip(QString("%1 – FAA: %2").arg(_pilot->planAircraftFull, _pilot->planAircraftFaa));
 
     if (_pilot->airline != 0) {

--- a/src/PilotDetails.ui
+++ b/src/PilotDetails.ui
@@ -98,6 +98,9 @@
           <property name="text">
            <string>A319</string>
           </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item>


### PR DESCRIPTION
This links the flightplan aircraft type in the pilot dialog to https://doc8643.com/ nicely.

Remark: The data is available on
https://applications.icao.int/dataservices/default.aspx, too but requires an API key.