### PR TITLE
[FEATURE] resolve Eurocontrol geographical waypoint format

### DIFF
--- a/src/Waypoint.cpp
+++ b/src/Waypoint.cpp
@@ -34,5 +34,9 @@ Waypoint::Waypoint(const QString& id, const double lat, const double lon) {
 }
 
 QString Waypoint::toolTip() const {
-    return label;
+    return QString("%1%2 %3%4")
+            .arg(lat > 0.? 'N': 'S')
+            .arg(abs(lat), 5, 'f', 2, '0')
+            .arg(lon > 0.? 'E': 'W')
+            .arg(abs(lon), 6, 'f', 2, '0');
 }


### PR DESCRIPTION
I don't know how official this format is but it is mentioned in the Eurocontrol IFPS manual as "geographic coordinates".

"Geographical co-ordinates shall consist of either 2 degrees latitude followed by 3 degrees longitude, or 2 degrees and 2 minutes latitude followed by 3 degrees and 2 minutes longitude or by 2 degrees, 2 minutes and 2 seconds latitude followed by 3 degrees, 2 minutes and 2 seconds longitude."

Examples: 46N078W 4620N05805W 462013N0580503W

So additionally to ARINC424 and some "what did that pilot mean?" best-guessing we am now also able to resolve this format.

Note: IFPS accepts also 4N40W and 04N40W as 04N040W. We only resolve the latter.