### PR TITLE
[FEATURE] (Re-)add position to controllers

### DIFF
--- a/QuteScoop.pro
+++ b/QuteScoop.pro
@@ -148,6 +148,7 @@ FORMS = \
     src/SectorView.ui \
     src/Window.ui
 HEADERS += \
+    src/helpers.h \
     src/WhazzupData.h \
     src/Whazzup.h \
     src/Waypoint.h \
@@ -160,7 +161,6 @@ HEADERS += \
     src/MapObject.h \
     src/MapScreen.h\
     src/LineReader.h \
-    src/helpers.h \
     src/SectorReader.h \
     src/Sector.h \
     src/FileReader.h \
@@ -194,7 +194,6 @@ HEADERS += \
     src/Route.h \
     src/PlanFlightRoutesModel.h \
     src/BookedAtcSortFilter.h \
-    src/helpers.h \
     src/ListClientsDialogModel.h \
     src/ListClientsDialog.h \
     src/Ping.h \

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -172,55 +172,6 @@ GLuint Sector::glBorderLineHighlighted() {
     return _borderlineHighlighted;
 }
 
-/* At 180 the longitude wraps around to -180
- * Since this can cause problems in the computation this adjusts point B relative to point A
- * such that the difference in longitude is less than 180
- * That is: Instead of going from a longitude of 179 in point A to a longitude of -179 in point B by going westwards
- * we set the longitude of point B to 181 to indicate that we're going east
- */
-void adjustPoint(const QPair<double, double> &a, QPair<double, double> &b) {
-    const double diff = a.second - b.second;
-    if(std::abs(diff) > 180)
-        b.second += ((diff > 0) - (diff < 0)) * 360;
-}
-
 QPair<double, double> Sector::getCenter() const {
-    // https://en.wikipedia.org/wiki/Centroid#Of_a_polygon
-
-    double A = 0;
-    QPair<double, double> runningTotal;
-    runningTotal.first = 0;
-    runningTotal.second = 0;
-
-    QPair<double, double> previous = m_points[0];
-
-    const int count = m_points.size();
-    for(int i = 0; i < count; ++i) {
-        QPair<double, double> current = m_points[i];
-        QPair<double, double> next = m_points[(i + 1) % count];
-        if(i > 0)
-            adjustPoint(previous, current);
-        adjustPoint(current, next);
-        previous = current;
-
-        A += (current.first * next.second
-             - next.first * current.second);
-
-        double multiplyBy = current.first * next.second
-                            - (next.first * current.second);
-
-        runningTotal.first += (current.first + next.first)
-                            * multiplyBy;
-        
-        runningTotal.second += (current.second + next.second)
-                            * multiplyBy;
-    }
-    A /= 2;
-
-    runningTotal.first /= 6 * A;
-    runningTotal.second /= 6 * A;
-
-    runningTotal.second = std::fmod(runningTotal.second + 180, 360) - 180;
-
-    return runningTotal;
+    return Helpers::polygonCenter(m_points);
 }


### PR DESCRIPTION
With the new VATSIM status data format we lost the lat/lon position of controllers. We use it to pan and zoom the map to a controller when "Show on map" is clicked in the controller detail dialog.

This adds the airport position(s) as controller position.

Fixes: #170 