### PR TITLE
[FEATURE] improve geographic waypoint resolving

### DIFF
--- a/src/Airac.h
+++ b/src/Airac.h
@@ -16,12 +16,12 @@ class Airac : public QObject {
         virtual ~Airac();
 
         Waypoint* waypoint(const QString &id, const QString &regionCode, const int &type) const;
-        Waypoint* waypointNearby(const QString &id, double lat, double lon, double maxDist) const;
+        Waypoint* waypointNearby(const QString &id, double lat, double lon, double maxDist);
 
         Airway* airway(const QString& name);
         Airway* airwayNearby(const QString& name, double lat, double lon) const;
 
-        QList<Waypoint*> resolveFlightplan(QStringList plan, double lat, double lon) const;
+        QList<Waypoint*> resolveFlightplan(QStringList plan, double lat, double lon);
 
         QSet<Waypoint*> allPoints;
         QHash<QString, QSet<Waypoint*> > fixes;

--- a/src/NavData.h
+++ b/src/NavData.h
@@ -21,6 +21,7 @@ class NavData: public QObject {
         static NavData *instance(bool createIfNoInstance = true);
         static QPair<double, double> *fromArinc(const QString &str);
         static QString toArinc(const short lat, const short lon);
+        static QString toEurocontrol(const double lat, const double lon);
 
         static double distance(double lat1, double lon1, double lat2, double lon2);
         static QPair<double, double> pointDistanceBearing(double lat, double lon,


### PR DESCRIPTION
This makes resolving more resilient while also removing some old guesses. It seems pilots (or planning software...) has been getting better at using common formats in flight plans.

For displaying, we try to use ARINC. If that does not have enough precision, we use the 453030N1213030W format with up to 4 decimals (or rather minutes and seconds).

Also some errors around non-full-degree waypoints for oceanic routes were removed.