### PR TITLE
[FEATURE] show relevant route parts

### DIFF
--- a/src/Airac.h
+++ b/src/Airac.h
@@ -16,12 +16,12 @@ class Airac : public QObject {
         virtual ~Airac();
 
         Waypoint* waypoint(const QString &id, const QString &regionCode, const int &type) const;
-        Waypoint* waypointNearby(const QString &id, double lat, double lon, double maxDist) const;
+        Waypoint* waypointNearby(const QString &id, double lat, double lon, double maxDist);
 
         Airway* airway(const QString& name);
         Airway* airwayNearby(const QString& name, double lat, double lon) const;
 
-        QList<Waypoint*> resolveFlightplan(QStringList plan, double lat, double lon) const;
+        QList<Waypoint*> resolveFlightplan(QStringList plan, double lat, double lon);
 
         QSet<Waypoint*> allPoints;
         QHash<QString, QSet<Waypoint*> > fixes;

--- a/src/Airport.cpp
+++ b/src/Airport.cpp
@@ -10,7 +10,7 @@
 #include "NavData.h"
 
 Airport::Airport(const QStringList& list, unsigned int debugLineNumber) :
-        showFlightLines(false),
+        showRoutes(false),
         _appDisplayList(0),
         _twrDisplayList(0), _gndDisplayList(0), _delDisplayList(0) {
     resetWhazzupStatus();

--- a/src/Airport.h
+++ b/src/Airport.h
@@ -50,7 +50,7 @@ class Airport: public MapObject {
 
         QString name, city, countryCode;
 
-        bool showFlightLines;
+        bool showRoutes;
 
         const GLuint &appDisplayList();
         const GLuint &twrDisplayList();

--- a/src/AirportDetails.cpp
+++ b/src/AirportDetails.cpp
@@ -148,7 +148,7 @@ void AirportDetails::refresh(Airport* newAirport) {
     groupBoxAtc->setTitle(QString("ATC (%1)").arg(atcContent.size()));
     treeAtc->header()->resizeSections(QHeaderView::ResizeToContents);
 
-    cbPlotRoutes->setChecked(_airport->showFlightLines);
+    cbPlotRoutes->setChecked(_airport->showRoutes);
 }
 
 void AirportDetails::atcSelected(const QModelIndex& index) {
@@ -164,8 +164,8 @@ void AirportDetails::departureSelected(const QModelIndex& index) {
 }
 
 void AirportDetails::togglePlotRoutes(bool checked) {
-    if(_airport->showFlightLines != checked) {
-        _airport->showFlightLines = checked;
+    if(_airport->showRoutes != checked) {
+        _airport->showRoutes = checked;
         if (Window::instance(false) != 0) {
             Window::instance()->mapScreen->glWidget->createPilotsList();
             Window::instance()->mapScreen->glWidget->updateGL();;

--- a/src/NavData.cpp
+++ b/src/NavData.cpp
@@ -346,16 +346,20 @@ QList<QPair<double, double> > NavData::greatCirclePoints(double lat1, double lon
 /**
   plot great-circles of lat/lon points on Earth
 **/
-void NavData::plotPointsOnEarth(const QList<QPair<double, double> > &points) {
+void NavData::plotGreatCirclePoints(const QList<QPair<double, double> > &points) {
     if (points.isEmpty())
         return;
     if (points.size() > 1) {
         DoublePair wpOld = points[0];
         for (int i=1; i < points.size(); i++) {
-            foreach(const DoublePair p, greatCirclePoints(wpOld.first, wpOld.second,
-                                                    points[i].first, points[i].second,
-                                                          400.))
+            auto subPoints = greatCirclePoints(
+                wpOld.first, wpOld.second,
+                points[i].first, points[i].second,
+                400.
+            );
+            foreach(const DoublePair p, subPoints) {
                 VERTEX(p.first, p.second);
+            }
             wpOld = points[i];
         }
     }

--- a/src/NavData.h
+++ b/src/NavData.h
@@ -21,6 +21,7 @@ class NavData: public QObject {
         static NavData *instance(bool createIfNoInstance = true);
         static QPair<double, double> *fromArinc(const QString &str);
         static QString toArinc(const short lat, const short lon);
+        static QString toEurocontrol(const double lat, const double lon);
 
         static double distance(double lat1, double lon1, double lat2, double lon2);
         static QPair<double, double> pointDistanceBearing(double lat, double lon,

--- a/src/NavData.h
+++ b/src/NavData.h
@@ -31,7 +31,7 @@ class NavData: public QObject {
                                                          double lat2, double lon2, double fraction);
         static QList<QPair<double, double> > greatCirclePoints(double lat1, double lon1, double lat2,
                                                               double lon2, double intervalNm = 30.);
-        static void plotPointsOnEarth(const QList<QPair<double, double> > &points);
+        static void plotGreatCirclePoints(const QList<QPair<double, double> > &points);
 
         virtual ~NavData();
 

--- a/src/Pilot.cpp
+++ b/src/Pilot.cpp
@@ -446,8 +446,7 @@ int Pilot::nextPointOnRoute(const QList<Waypoint *> &waypoints) const { // next 
                                        waypoints[0]->lon);
     int minPoint = 0; // next to departure as default
     for(int i = 1; i < waypoints.size(); i++) {
-        if(NavData::distance(lat, lon, waypoints[i]->lat, waypoints[i]->lon) <
-           minDist) {
+        if(NavData::distance(lat, lon, waypoints[i]->lat, waypoints[i]->lon) < minDist) {
             minDist = NavData::distance(lat, lon, waypoints[i]->lat, waypoints[i]->lon);
             minPoint = i;
         }
@@ -477,19 +476,35 @@ int Pilot::nextPointOnRoute(const QList<Waypoint *> &waypoints) const { // next 
 }
 
 bool Pilot::showDepLine() const {
-    if (depAirport() != 0)
-        return (Settings::depLineStrength() > 0. &&
-                (showDepDestLine || depAirport()->showFlightLines));
-    else
-        return (Settings::depLineStrength() > 0. && showDepDestLine);
+    if (qFuzzyIsNull(Settings::depLineStrength())) {
+        return false;
+    }
+
+    if (showDepDestLine) {
+        return true;
+    }
+
+    if (depAirport() != 0) {
+        return depAirport()->showRoutes;
+    }
+
+    return false;
 }
 
 bool Pilot::showDestLine() const {
-    if (destAirport() != 0)
-        return (Settings::destLineStrength() > 0. &&
-                (showDepDestLine || destAirport()->showFlightLines));
-    else
-        return (Settings::destLineStrength() > 0. && showDepDestLine);
+    if (qFuzzyIsNull(Settings::destLineStrength())) {
+        return false;
+    }
+
+    if (showDepDestLine) {
+        return true;
+    }
+
+    if (destAirport() != 0) {
+        return destAirport()->showRoutes;
+    }
+
+    return false;
 }
 
 QList<Waypoint*> Pilot::routeWaypoints() {

--- a/src/PilotDetails.cpp
+++ b/src/PilotDetails.cpp
@@ -145,9 +145,9 @@ void PilotDetails::refresh(Pilot *pilot) {
     // plotted?
     bool plottedAirports = false;
     if (_pilot->depAirport() != 0)
-        plottedAirports |= _pilot->depAirport()->showFlightLines;
+        plottedAirports |= _pilot->depAirport()->showRoutes;
     if (_pilot->destAirport() != 0)
-        plottedAirports |= _pilot->destAirport()->showFlightLines;
+        plottedAirports |= _pilot->destAirport()->showRoutes;
 
     if (!plottedAirports && !_pilot->showDepDestLine)
         cbPlotRoute->setCheckState(Qt::Unchecked);

--- a/src/PlanFlightDialog.cpp
+++ b/src/PlanFlightDialog.cpp
@@ -274,7 +274,7 @@ void PlanFlightDialog::plotPlannedRoute() const {
     glColor4f(0., 0., 1., 1.);
     glLineWidth(3.);
     glBegin(GL_LINE_STRIP);
-    NavData::plotPointsOnEarth(points);
+    NavData::plotGreatCirclePoints(points);
     glEnd();
     glPointSize(4.);
     glColor4f(1., 0., 0., 1.);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -842,7 +842,7 @@ void Window::on_actionShowRoutes_triggered(bool checked) {
     qDebug() << "Window::on_actionShowRoutes_triggered()" << checked;
     GuiMessages::message(QString("toggled routes [%1]").arg(checked? "on": "off"), "routeToggle");
     foreach(Airport *a, NavData::instance()->airports.values()) // synonym to "toggle routes" on all airports
-        a->showFlightLines = checked;
+        a->showRoutes = checked;
     if (!checked) { // when disabled, this shall clear all routes
         foreach (Pilot *p, Whazzup::instance()->whazzupData().allPilots())
             p->showDepDestLine = false;


### PR DESCRIPTION
This allows to use plotted routes better for a short-term situation
preview.
    
It shows the less relevant future part of a route with more transparency and
with a slimmer line.
    
The cutoff time is taken from
Preferences -> Display(airports) -> traffic -> arriving in ... hours
(and halved).
    
The used style for the relevant part of the future route is still
Preferences -> Display (sectors & pilots) -> Pilots -> plot to
destination.
    
The less relevant part derives from that style, but is
* 20% darker
* 50% less opaque
* half the width (but min. 0.5 pixels)
    
Fixes: #225
Based on: #226
