### PR TITLE
[BUGFIX] Prevent Earth triangles from showing their borders

### DIFF
--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -784,14 +784,10 @@ void GLWidget::initializeGL() {
     }
     if(Settings::displaySmoothLines()) {
         glEnable(GL_LINE_SMOOTH);
-        glEnable(GL_POLYGON_SMOOTH);
         glHint(GL_LINE_SMOOTH_HINT, GL_NICEST); // GL_FASTEST, GL_NICEST, GL_DONT_CARE
-        glHint(GL_POLYGON_SMOOTH_HINT, GL_NICEST);
     } else {
         glDisable(GL_LINE_SMOOTH);
-        glDisable(GL_POLYGON_SMOOTH);
         glHint(GL_LINE_SMOOTH_HINT, GL_FASTEST); // GL_FASTEST, GL_NICEST, GL_DONT_CARE
-        glHint(GL_POLYGON_SMOOTH_HINT, GL_FASTEST);
     }
     if (Settings::glBlending()) {
         glEnable(GL_BLEND);


### PR DESCRIPTION
I had these ugly lines on an Nvidia GTX 3060:

![image](https://github.com/qutescoop/qutescoop/assets/1678001/2be02e7d-369a-4123-b7a3-5bcbeddad2bf)


Digging a bit brought me to a list of common OpenGL mistakes... https://www.khronos.org/opengl/wiki/Common_Mistakes#glEnable.28GL_POLYGON_SMOOTH.29

So..., now GL_POLYGON_SMOOTH is off.