### PR TITLE
[TASK] only show relevant "friends"

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -3,7 +3,6 @@
  **************************************************************************/
 
 #include "Controller.h"
-#include "helpers.h"
 
 #include "Client.h"
 #include "ControllerDetails.h"
@@ -75,21 +74,9 @@ Controller::Controller(const QJsonObject& json, const WhazzupData* whazzup):
     } else {
         // We try to get lat/lng from covered airports
         auto _airports = airports();
-        if (_airports.size() == 1) {
+        if (_airports.size() > 0) {
             lat = _airports[0]->lat;
             lon = _airports[0]->lon;
-        } else if (_airports.size() > 1) {
-        QList<QPair<double, double>> points;
-            foreach(auto *_a, _airports) {
-                if (_a == 0) {
-                    continue;
-                }
-                points.append(DoublePair(_a->lat, _a->lon));
-            }
-
-            auto center = Helpers::polygonCenter(points);
-            lat = center.first;
-            lon = center.second;
         }
     }
 }

--- a/src/FriendsVisitor.cpp
+++ b/src/FriendsVisitor.cpp
@@ -1,24 +1,33 @@
 /**************************************************************************
- *  This file is part of QuteScoop. See README for license
- **************************************************************************/
+*  This file is part of QuteScoop. See README for license
+**************************************************************************/
 
 #include "FriendsVisitor.h"
 #include "Settings.h"
 #include "Client.h"
+#include "Controller.h"
 
 FriendsVisitor::FriendsVisitor() {
     _friendList = Settings::friends();
 }
 
 void FriendsVisitor::visit(MapObject* object) {
-    Client *c = dynamic_cast<Client*>(object);
-    if(c != 0) {
-        if(c->isFriend()) {
-            _friends.append(c);
+    Client* c = dynamic_cast<Client*>(object);
+    if (c == 0) {
+        return;
+    }
+    if (!c->isFriend()) {
+        return;
+    }
+    Controller* co = dynamic_cast<Controller*>(object);
+    if (co != 0) {
+        if (co->isAtis()) {
+            return;
         }
     }
+    _friends.append(c);
 }
 
-QList<MapObject *> FriendsVisitor::result() const {
+QList<MapObject*> FriendsVisitor::result() const {
     return _friends;
 }

--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -1090,7 +1090,7 @@ void GLWidget::paintGL() {
             destroyFriendHightlighter();
         }
 
-        foreach(const auto &_friend, _friends) {
+        foreach(const auto &_friend, m_friendPositions) {
             if (qFuzzyIsNull(_friend.first) && qFuzzyIsNull(_friend.second))
                 continue;
 
@@ -1895,7 +1895,7 @@ void GLWidget::newWhazzupData(bool isNew) {
         createPilotsList();
         createAirportsList();
         createControllersLists();
-        _friends = Whazzup::instance()->whazzupData().friendsLatLon();
+        m_friendPositions = Whazzup::instance()->whazzupData().friendsLatLon();
 
         updateGL();
     }

--- a/src/GLWidget.h
+++ b/src/GLWidget.h
@@ -125,7 +125,7 @@ class GLWidget : public QGLWidget {
         _controllerLabelZoomTreshold, _allWaypointsLabelZoomTreshold, _usedWaypointsLabelZoomThreshold,
         _xRot, _yRot, _zRot, _zoom, _aspectRatio;
         QTimer *_highlighter;
-        QList< QPair<double , double> > _friends;
+        QList< QPair<double , double> > m_friendPositions;
 };
 
 #endif /*GLWIDGET_H_*/

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -464,6 +464,9 @@ QList<QPair<double, double> > WhazzupData::friendsLatLon() const
     QStringList friends = Settings::friends();
     QList<QPair<double, double> > result;
     foreach (Controller* c, controllers.values()) {
+        if (c->isAtis()) {
+            continue;
+        }
         if (friends.contains(c->userId)) {
             result.append(QPair<double, double>(c->lat, c->lon));
         }


### PR DESCRIPTION
This always hides _ATIS pseudo logins from friend lists and the friend map display.

It also removes the "middle" calculation for controllers with multiple airports: We now just take the lat/lon of the first airport.

Fixes: #236