### PR TITLE
[BUGFIX] fix nesting and order of OpenGL calls

### DIFF
--- a/src/Airport.cpp
+++ b/src/Airport.cpp
@@ -123,8 +123,8 @@ void Airport::appGl(const QColor &middleColor, const QColor &marginColor, const 
     }
     glEnd();
 
-    glBegin(GL_LINE_STRIP);
     glLineWidth(borderLineWidth);
+    glBegin(GL_LINE_STRIP);
     glColor4f(borderColor.redF(), borderColor.greenF(), borderColor.blueF(), borderColor.alphaF());
     for(short int i = 0; i <= 360; i += 1) {
         auto _p = NavData::pointDistanceBearing(lat, lon, Airport::symbologyAppRadius_nm, i);

--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -717,7 +717,6 @@ void GLWidget::createStaticLists() {
         glLineWidth(Settings::countryLineStrength());
         LineReader countries = LineReader(Settings::dataDirectory("data/countries.dat"));
         QList<QPair<double, double> > line = countries.readLine();
-        glBegin(GL_LINE);
         while (!line.isEmpty()) {
             glBegin(GL_LINE_STRIP);
             for (int i = 0; i < line.size(); i++)
@@ -725,7 +724,6 @@ void GLWidget::createStaticLists() {
             glEnd();
             line = countries.readLine();
         }
-        glEnd();
     }
     glEndList();
 

--- a/src/PlanFlightDialog.cpp
+++ b/src/PlanFlightDialog.cpp
@@ -271,13 +271,13 @@ void PlanFlightDialog::plotPlannedRoute() const {
 
     // @todo: make plot line color adjustable
     // @todo: are we GLing here ouside a GL context?!
-    glColor4f(0., 0., 1., 1.);
-    glLineWidth(3.);
+    glColor4f(.7, 1., .4, .8);
+    glLineWidth(2.);
     glBegin(GL_LINE_STRIP);
     NavData::plotGreatCirclePoints(points);
     glEnd();
     glPointSize(4.);
-    glColor4f(1., 0., 0., 1.);
+    glColor4f(.5, .5, .5, .5);
     glBegin(GL_POINTS);
     foreach(const DoublePair p, points)
         VERTEX(p.first, p.second);


### PR DESCRIPTION
This removes an erroneous nesting of OpenGL calls and fixes the APP border width call.

As a drive-by it sets a nicer color for the "Plan Flight" plotted route.