### PR TITLE
[TASK] Add KDFW controller airports

### DIFF
--- a/data/controllerAirportsMapping.dat
+++ b/data/controllerAirportsMapping.dat
@@ -63,6 +63,8 @@ WIII:APP DEP:WICA WICC WIHH WILL WIRR
 
 ; USA
 MSP:APP DEP:KSTP KFCM KANE KMIC
+; https://zfwartcc.net/files/documents
+REG:APP DEP:KADS KAFW KDAL KDFW KDTO KFTW KFWS KGKY KGPM KHQZ KNFW KRBD KTKI
 SDF:APP DEP:KLOU
 
 ;---------------------------------------------------------------------------------------------

--- a/data/dataversions.txt
+++ b/data/dataversions.txt
@@ -6,6 +6,6 @@ station.dat%%246
 countrycodes.dat%%119
 firdisplay.dat%%330
 airports.dat%%340
-controllerAirportsMapping.dat%%5
+controllerAirportsMapping.dat%%6
 coastline.dat%%118
 firlist.dat%%336


### PR DESCRIPTION
I haven't fully understood who does what when there are multiple online, but basically the REG_* approach controllers (callsign "Regional Approach") are lower sectors in the KDFW area.