### PR TITLE
[TASK] Tweak waypoint resolving

### DIFF
--- a/src/Airac.cpp
+++ b/src/Airac.cpp
@@ -272,11 +272,12 @@ Waypoint* Airac::waypointNearby(const QString& input, double lat, double lon, do
                             "((\\d{2})?)"
                             "((\\d{2})?)"
                             "([NS])"
-                            "(\\d{3})"
+                            "(\\d{2,3})"
                             "((\\d{2})?)"
                             "((\\d{2})?)"
                             "([EW])"); // things that are valid for the Eurocontrol route validator:
                     // 63N005W or 6330N00530W (minutes) or 633000N0053000W (minutes and seconds)
+                    // we are not strict and also allow 2-char longitudes like 63N05W
         QRegExp slash("([\\-]?\\d{2})/([\\-]?\\d{2,3})"); // some pilots
                                                 // ..like to use non-standard: -53/170
 
@@ -290,7 +291,7 @@ Waypoint* Airac::waypointNearby(const QString& input, double lat, double lon, do
                 foundLon = arincP->second;
             }
             delete arincP;
-        } else if (eurocontrol.exactMatch(input)) { // 63N005W or 6330N00530W (minutes) or 633000N0053000W (minutes and seconds)
+        } else if (eurocontrol.exactMatch(input)) {
             auto capturedTexts = eurocontrol.capturedTexts();
 
             double wLat = capturedTexts[1].toDouble() + capturedTexts[2].toDouble() / 60. + capturedTexts[4].toDouble() / 3600.;
@@ -403,7 +404,8 @@ QList<Waypoint*> Airac::resolveFlightplan(QStringList plan, double lat, double l
             wantAirway = false;
             // have airway - next should be a waypoint
             QString endId = fpTokenToWaypoint(plan.first());
-            Waypoint* wp = waypointNearby(endId, lat, lon);
+            // 5500NM is the longest legitimate route part (PACOT entry-exit) that we can't resolve
+            Waypoint* wp = waypointNearby(endId, lat, lon, 5500.);
             if(wp != 0) {
                 if (currPoint != 0) {
                     auto _expand = awy->expand(currPoint->label, wp->label);
@@ -427,7 +429,7 @@ QList<Waypoint*> Airac::resolveFlightplan(QStringList plan, double lat, double l
                 }
             }
 
-            Waypoint* wp = waypointNearby(id, lat, lon);
+            Waypoint* wp = waypointNearby(id, lat, lon, 5500.);
             if(wp != 0) {
                 result.append(wp);
                 currPoint = wp;

--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -1801,11 +1801,7 @@ void GLWidget::drawSelectionRectangle() {
             const QFontMetricsF fontMetrics(font, this);
 
             // show position label
-            const QString currText = QString("%1%2 %3%4").
-                    arg(currLat > 0? "N": "S").
-                    arg(qAbs(currLat), 5, 'f', 2, '0').
-                    arg(currLon > 0? "E": "W").
-                    arg(qAbs(currLon), 6, 'f', 2, '0');
+            const QString currText = NavData::toEurocontrol(currLat, currLon);
             int x, y;
             if (isPointVisible(currLat, currLon, &x, &y)) {
                 glColor4f(0., 0., 0., .7);
@@ -1823,10 +1819,8 @@ void GLWidget::drawSelectionRectangle() {
             }
 
             // show distance label
-            const DoublePair middle = NavData::greatCircleFraction(downLat, downLon,
-                                                             currLat, currLon,
-                                                             .5);
-            const QString middleText = QString("%1 NM / TC %2deg").arg(
+            const DoublePair middle = NavData::greatCircleFraction(downLat, downLon, currLat, currLon, .5);
+            const QString middleText = QString("%1 NM / TC %2 deg").arg(
                 NavData::distance(downLat, downLon, currLat, currLon),
                 0, 'f', 1
             ).arg(

--- a/src/NavData.cpp
+++ b/src/NavData.cpp
@@ -375,6 +375,13 @@ QPair<double, double>*NavData::fromArinc(const QString &str) {
         auto capturedTexts = arinc.capturedTexts();
         if (
             !capturedTexts[2].isEmpty()
+            && !capturedTexts[4].isEmpty()
+            ) {
+            return 0;
+        }
+
+        if (
+            !capturedTexts[2].isEmpty()
             || !capturedTexts[4].isEmpty()
         ) {
             double wLat = capturedTexts[1].toDouble();
@@ -441,7 +448,7 @@ QString NavData::toArinc(const short lat, const short lon) {
 /** converts geographic points to "Eurocontrol" (that's just how I call it, it's the basic 40N030W) format
   @return QString("") on error
 */
-QString NavData::toEurocontrol(double lat, double lon) {
+QString NavData::toEurocontrol(double lat, double lon, const LatLngPrecission maxPrecision) {
     if (qAbs(lat) > 90 || qAbs(lon) > 180) {
         return QString();
     }
@@ -459,32 +466,36 @@ QString NavData::toEurocontrol(double lat, double lon) {
     ushort latDeg = floor(lat);
     ushort lonDeg = floor(lon);
 
-    ushort latMin = (int)(lat * 60.) % 60;
-    ushort lonMin = (int)(lon * 60.) % 60;
+    if (maxPrecision >= LatLngPrecission::Mins) {
+        ushort latMin = (int)(lat * 60.) % 60;
+        ushort lonMin = (int)(lon * 60.) % 60;
 
-    ushort latSec = (int)(lat * 3600.) % 60;
-    ushort lonSec = (int)(lon * 3600.) % 60;
+        if (maxPrecision >= LatLngPrecission::Secs) {
+            ushort latSec = (int)(lat * 3600.) % 60;
+            ushort lonSec = (int)(lon * 3600.) % 60;
 
-    if (latSec != 0 || lonSec != 0) {
-        return QString("%1%2%3%4%5%6%7%8")
-            .arg(latDeg, 2, 10, QChar('0'))
-            .arg(latMin, 2, 10, QChar('0'))
-            .arg(latSec, 2, 10, QChar('0'))
-            .arg(latLetter)
-            .arg(lonDeg, 3, 10, QChar('0'))
-            .arg(lonMin, 2, 10, QChar('0'))
-            .arg(lonSec, 2, 10, QChar('0'))
-            .arg(lonLetter);
-    }
+            if (latSec != 0 || lonSec != 0) {
+                return QString("%1%2%3%4%5%6%7%8")
+                    .arg(latDeg, 2, 10, QChar('0'))
+                    .arg(latMin, 2, 10, QChar('0'))
+                    .arg(latSec, 2, 10, QChar('0'))
+                    .arg(latLetter)
+                    .arg(lonDeg, 3, 10, QChar('0'))
+                    .arg(lonMin, 2, 10, QChar('0'))
+                    .arg(lonSec, 2, 10, QChar('0'))
+                    .arg(lonLetter);
+            }
+        }
 
-    if (latMin != 0 || lonMin != 0) {
-        return QString("%1%2%3%4%5%6")
-            .arg(latDeg, 2, 10, QChar('0'))
-            .arg(latMin, 2, 10, QChar('0'))
-            .arg(latLetter)
-            .arg(lonDeg, 3, 10, QChar('0'))
-            .arg(lonMin, 2, 10, QChar('0'))
-            .arg(lonLetter);
+        if (latMin != 0 || lonMin != 0) {
+            return QString("%1%2%3%4%5%6")
+                .arg(latDeg, 2, 10, QChar('0'))
+                .arg(latMin, 2, 10, QChar('0'))
+                .arg(latLetter)
+                .arg(lonDeg, 3, 10, QChar('0'))
+                .arg(lonMin, 2, 10, QChar('0'))
+                .arg(lonLetter);
+        }
     }
 
     return QString("%1%2%3%4")

--- a/src/NavData.h
+++ b/src/NavData.h
@@ -15,13 +15,17 @@ struct ControllerAirportsMapping {
     QList<Airport*> airports;
 };
 
+enum LatLngPrecission {
+    Secs = 3, Mins = 2, Degrees = 1
+};
+
 class NavData: public QObject {
         Q_OBJECT
     public:
         static NavData *instance(bool createIfNoInstance = true);
         static QPair<double, double> *fromArinc(const QString &str);
         static QString toArinc(const short lat, const short lon);
-        static QString toEurocontrol(const double lat, const double lon);
+        static QString toEurocontrol(const double lat, const double lon, const LatLngPrecission maxPrecision = LatLngPrecission::Secs);
 
         static double distance(double lat1, double lon1, double lat2, double lon2);
         static QPair<double, double> pointDistanceBearing(double lat, double lon,

--- a/src/Pilot.cpp
+++ b/src/Pilot.cpp
@@ -543,12 +543,12 @@ QString Pilot::routeWaypointsStr() {
 
 QList<Waypoint*> Pilot::routeWaypointsWithDepDest() {
     QList<Waypoint*> waypoints = routeWaypoints();
-    if(depAirport() != 0)
-        waypoints.prepend(new Waypoint(depAirport()->label, depAirport()->lat,
-                                       depAirport()->lon));
-    if(destAirport() != 0)
-        waypoints.append(new Waypoint(destAirport()->label, destAirport()->lat,
-                                      destAirport()->lon));
+    if(depAirport() != 0) {
+        waypoints.prepend(new Waypoint(depAirport()->label, depAirport()->lat, depAirport()->lon));
+    }
+    if(destAirport() != 0) {
+        waypoints.append(new Waypoint(destAirport()->label, destAirport()->lat, destAirport()->lon));
+    }
     return waypoints;
 }
 

--- a/src/Waypoint.cpp
+++ b/src/Waypoint.cpp
@@ -2,6 +2,7 @@
  *  This file is part of QuteScoop. See README for license
  **************************************************************************/
 
+#include "NavData.h"
 #include "Waypoint.h"
 
 Waypoint::Waypoint(const QStringList& stringList) {
@@ -34,9 +35,5 @@ Waypoint::Waypoint(const QString& id, const double lat, const double lon) {
 }
 
 QString Waypoint::toolTip() const {
-    return QString("%1%2 %3%4")
-            .arg(lat > 0.? 'N': 'S')
-            .arg(abs(lat), 5, 'f', 2, '0')
-            .arg(lon > 0.? 'E': 'W')
-            .arg(abs(lon), 6, 'f', 2, '0');
+    return NavData::toEurocontrol(lat, lon, LatLngPrecission::Secs);
 }


### PR DESCRIPTION
* Allow 2/4/6-char E/W in 30N20W ("Eurocontrol") format.
* When building an output string for lat/lng, prefer the "Eurocontrol" format, except for waypoint names (the Navdata comes with some ARINC waypoints already so I decided to stick with that where feasible).
* Add function for fixed precision output for the Eurocontrol format.
* Fix wrong ARINC matches.
* In routes, only resolve waypoints closer than 5500NM from the previous one. That will cut down on some erroneous "routes across the globe" for typos (or VFR freetext) in route waypoints. 
  We need the 5500NM for legitimate routes because that's the length of the longest PACOT routes.