### PR TITLE
[TASK] Use configured FIR font for selection rectangle

### DIFF
--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -1797,7 +1797,7 @@ void GLWidget::drawSelectionRectangle() {
             glEnd();
 
             // information labels
-            const QFont font = QFont(); //Settings::firFont();
+            const QFont font = Settings::firFont();
             const QFontMetricsF fontMetrics(font, this);
 
             // show position label


### PR DESCRIPTION
That used the default font before - not a good match if you otherwise selected custom fonts for map labels.