### PR TITLE
[BUGFIX] Suppress "toggled routes" message during startup

### DIFF
--- a/src/GuiMessage.cpp
+++ b/src/GuiMessage.cpp
@@ -122,7 +122,7 @@ void GuiMessages::progressBarDestroyed(QObject *obj) {
 
 ///////////////////////////////////////////////////////////////////////////
 // INTERNALLY USED CLASS AND METHODS (called by static methods)
-void GuiMessages::updateMessage(GuiMessage *gm, bool callUpdate) {
+void GuiMessages::updateMessage(GuiMessage *gm) {
     //qDebug() << "GuiMessages::updateMessage()" << guiMessage;
     GuiMessage *existing = messageById(gm->id, gm->type);
     if (existing != 0) {
@@ -141,10 +141,9 @@ void GuiMessages::updateMessage(GuiMessage *gm, bool callUpdate) {
         // qDebug() << "GuiMessage()::updateMessage() new" << gm;
         _messages.insert(gm->type, gm);
     }
-    if (callUpdate)
-        update();
+    update();
 }
-void GuiMessages::removeMessageById(const QString &id, bool callUpdate) {
+void GuiMessages::removeMessageById(const QString &id) {
     // qDebug() << "GuiMessages::removeMessage() id=" << id;
     foreach(int key, _messages.keys()) {
         foreach(GuiMessage *gm, _messages.values(key)) {
@@ -159,8 +158,7 @@ void GuiMessages::removeMessageById(const QString &id, bool callUpdate) {
             }
         }
     }
-    if (callUpdate)
-        update();
+    update();
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/GuiMessage.h
+++ b/src/GuiMessage.h
@@ -86,8 +86,8 @@ class GuiMessages : public QObject {
         };
         ///////////////////////////////////////////////////////////////////////////
         // INTERNALLY USED METHODS (public to be callable out of static methods)
-        void updateMessage(GuiMessage *gm, bool callUpdate = true);
-        void removeMessageById(const QString &id, bool callUpdate = true);
+        void updateMessage(GuiMessage *gm);
+        void removeMessageById(const QString &id);
     public slots:
         void labelDestroyed(QObject *obj);
         void progressBarDestroyed(QObject *obj);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -84,9 +84,16 @@ Window::Window(QWidget *parent) :
     setEnableBookedAtc(Settings::downloadBookings());
     actionShowWaypoints->setChecked(Settings::showUsedWaypoints());
 
-    connect(actionShowRoutes, &QAction::toggled, this, &Window::actionShowRoutes_triggered);
     actionShowRoutes->setChecked(Settings::showRoutes());
-    actionShowRoutes_triggered(Settings::showRoutes());
+    connect(
+        actionShowRoutes,
+        &QAction::toggled,
+        this,
+        [=]( const bool &newValue ) {
+            actionShowRoutes_triggered(newValue);
+        }
+    );
+    actionShowRoutes_triggered(Settings::showRoutes(), false);
 
     Whazzup *whazzup = Whazzup::instance();
     connect(actionDownload, &QAction::triggered, whazzup, &Whazzup::downloadJson3);
@@ -841,10 +848,12 @@ void Window::shootScreenshot() {
     qDebug() << "Window::shootScreenshot()" << QString("%1.png").arg(filename); //fixme
 }
 
-void Window::actionShowRoutes_triggered(bool checked) {
+void Window::actionShowRoutes_triggered(bool checked, bool showStatus) {
     qDebug() << "Window::on_actionShowRoutes_triggered()" << checked;
     Settings::setShowRoutes(checked);
-    GuiMessages::message(QString("toggled routes [%1]").arg(checked? "on": "off"), "routeToggle");
+    if (showStatus) {
+        GuiMessages::message(QString("toggled routes [%1]").arg(checked? "on": "off"), "routeToggle");
+    }
     foreach(Airport *a, NavData::instance()->airports.values()) // synonym to "toggle routes" on all airports
         a->showRoutes = checked;
     if (!checked) { // when disabled, this shall clear all routes

--- a/src/Window.h
+++ b/src/Window.h
@@ -28,7 +28,7 @@ class Window : public QMainWindow, public Ui::Window {
         void restored();
         void cloudDownloaded();
     private slots:
-        void actionShowRoutes_triggered(bool checked);
+        void actionShowRoutes_triggered(bool checked, bool showStatus = true);
         void on_actionShowWaypoints_triggered(bool checked);
         void on_actionHighlight_Friends_triggered(bool checked);
         void on_pb_highlightFriends_toggled(bool checked);


### PR DESCRIPTION
We started remembering the "Show routes" setting between startups. On startup, the setting was restored but that lead to an annoying "toggled routes [on]" message in the startup screen.

This also cleans up unneeded function parameters around GuiMessage.