### PR TITLE
[FEATURE] Beautify route and RMK/ flightplan representation

### DIFF
--- a/src/PlanFlightDialog.cpp
+++ b/src/PlanFlightDialog.cpp
@@ -259,10 +259,10 @@ void PlanFlightDialog::routeSelected(const QModelIndex& index) {
 
 void PlanFlightDialog::plotPlannedRoute() const {
     if(selectedRoute == 0 || !cbPlot->isChecked()) {
-        lblPlotStatus->setText("no route to plot");
+        lblPlotStatus->setText("<span style='color: " + Settings::lightTextColor().name(QColor::HexArgb) + "'>no route to plot</span>");
         return;
     }
-    lblPlotStatus->setText(QString("waypoints (calculated): <code>%1</code>").arg(selectedRoute->waypointsStr));
+    lblPlotStatus->setText(QString("<span style='color: " + Settings::lightTextColor().name(QColor::HexArgb) + "'>waypoints (calculated): <code>%1</code></span>").arg(selectedRoute->waypointsStr));
     if(selectedRoute->waypoints.size() < 2)
         return;
     QList<DoublePair> points;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -102,7 +102,15 @@ void Settings::importFromFile(QString fileName) {
 **/
 QString Settings::dataDirectory(const QString &composeFilePath) {
     return QString("%1/%2")
-            .arg(QCoreApplication::applicationDirPath(), composeFilePath);
+        .arg(QCoreApplication::applicationDirPath(), composeFilePath);
+}
+
+const QColor Settings::lightTextColor()
+{
+    auto _default = QGuiApplication::palette().text().color();
+    _default.setAlphaF(.5);
+
+    return instance()->value("display/lightTextColor", _default).value<QColor>();
 }
 
 bool Settings::shootScreenshots() {

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -18,6 +18,9 @@ class Settings {
         // data directory
         static QString dataDirectory(const QString& composeFilePath = QString(""));
 
+        // "constant" settings
+        static const QColor lightTextColor();
+
         // saved settings
         static void saveState(const QByteArray& state);
         static QByteArray savedState();


### PR DESCRIPTION
This visually breaks apart waypoint amendment strings like /N0180F050 and remarks like RMK/beginner.

It uses a lighter text color that is currently hard-coded as 50% opacity from normal text.

![image](https://github.com/qutescoop/qutescoop/assets/1678001/3f4cd022-b815-4f86-9a34-623a363f9972)
