### PR TITLE
[BUGFIX] only load VOR/NDB navaids

### DIFF
--- a/src/Airac.cpp
+++ b/src/Airac.cpp
@@ -125,7 +125,10 @@ void Airac::readNavaids(const QString& directory) {
         if (nav == 0 || nav->isNull())
             continue;
 
-        navaids[nav->label].insert(nav);
+        // we ignore all the rest (for now)
+        if (nav->type() == NavAid::Type::NDB || nav->type() == NavAid::Type::VOR) {
+            navaids[nav->label].insert(nav);
+        }
     }
     qDebug() << "Read navaids from" << (directory + "/earth_nav.dat")
             << "-" << navaids.size() << "imported";

--- a/src/Launcher.cpp
+++ b/src/Launcher.cpp
@@ -254,8 +254,7 @@ void Launcher::dataFileDownloaded() {
         // error?
         if(_replyDataVersionsAndFiles->error() != QNetworkReply::NoError) {
             GuiMessages::criticalUserInteraction(QString("Error downloading %1:\n%2")
-                    .arg(_replyDataVersionsAndFiles->url().toString())
-                    .arg(_replyDataVersionsAndFiles->errorString()),
+                    .arg(_replyDataVersionsAndFiles->url().toString(), _replyDataVersionsAndFiles->errorString()),
                     "New datafiles");
         } else {
             // saving file
@@ -295,7 +294,7 @@ void Launcher::dataFileDownloaded() {
     } else {
         // we are finished
         GuiMessages::infoUserAttention(
-                    "These changes will take effect on the next start of QuteScoop.",
+                    "New data has been downloaded.",
                     "New datafiles");
         // updating local dataversions.txt
         QFile localDataVersionsFile(Settings::dataDirectory("data/dataversions.txt"));

--- a/src/NavAid.cpp
+++ b/src/NavAid.cpp
@@ -41,6 +41,7 @@ NavAid::NavAid(const QStringList&stringList) {
     _name = "";
     for (int i = 10; i < stringList.size(); i++)
         _name += stringList[i] + (i > 9? " ": "");
+    _name = _name.trimmed();
 }
 
 QString NavAid::typeStr(Type type) {
@@ -65,6 +66,8 @@ QString NavAid::typeStr(Type type) {
 
 QString NavAid::toolTip() const {
     QString ret = Waypoint::toolTip();
+    ret.append(" (" + _name + ")");
+
     if (_type == NDB)
         ret.append(QString(" %1 kHz").arg(_freq));
     else if (_type == VOR || _type == DME || _type == DME_NO_FREQ || _type == ILS_LOC || _type == LOC || _type == GS)


### PR DESCRIPTION
We previously loaded all kind of navaids (ILSs, GBAS stations, ...). This lead to problems in route resolving.