### PR TITLE
[EFATURE] Allow shorter Whazzup download intervals

### DIFF
--- a/src/NavData.cpp
+++ b/src/NavData.cpp
@@ -223,7 +223,6 @@ QSet<Airport*> NavData::additionalMatchedAirportsForController(QString prefix, Q
 }
 
 void NavData::updateData(const WhazzupData& whazzupData) {
-    qApp->setOverrideCursor(QCursor(Qt::WaitCursor));
     qDebug() << "NavData::updateData() on" << airports.size() << "airports";
     foreach (Airport* a, activeAirports.values()) {
         a->resetWhazzupStatus();
@@ -281,7 +280,6 @@ void NavData::updateData(const WhazzupData& whazzupData) {
     }
 
     qDebug() << "NavData::updateData() -- finished";
-    qApp->restoreOverrideCursor();
 }
 
 void NavData::accept(SearchVisitor* visitor) {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -95,7 +95,7 @@ void Settings::migrate(QSettings* settingsInstance) {
                     if (settingsInstance->contains(fromTo.first)) {
                         settingsInstance->setValue(
                             fromTo.second,
-                            instance()->value(fromTo.first).value<double>()
+                            settingsInstance->value(fromTo.first).value<double>()
                         );
                         qDebug() << "replaced" << fromTo.first << "with" << fromTo.second;
                         settingsInstance->remove(fromTo.first);
@@ -120,6 +120,16 @@ void Settings::migrate(QSettings* settingsInstance) {
                 foreach (const auto setting, obsoleteSettings) {
                     settingsInstance->remove(setting);
                 }
+            }
+        },
+        {
+            6,
+            "Whazzup download interval is now seconds",
+            [settingsInstance]() {
+                settingsInstance->setValue(
+                    "download/interval",
+                    settingsInstance->value("download/interval", 1).value<int>() * 60
+                );
             }
         }
     };
@@ -174,13 +184,14 @@ const QColor Settings::lightTextColor() {
 }
 
 int Settings::downloadInterval() {
-    return instance()->value("download/interval", 2).toInt();
+    return instance()->value("download/interval", 60).toInt();
 }
 void Settings::setDownloadInterval(int value) {
     instance()->setValue("download/interval", value);
 }
 
 bool Settings::downloadOnStartup() {
+    // policy: see https://github.com/vatsimnetwork/developer-info/wiki/Data-Feeds-Live-Data
     return instance()->value("download/downloadOnStartup", true).toBool();
 }
 

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -18,9 +18,8 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type)
       updateEarliest(QDateTime()), whazzupTime(QDateTime()),
       bookingsTime(QDateTime()) {
     qDebug() << "WhazzupData::WhazzupData(buffer)" << type << "[NONE, WHAZZUP, ATCBOOKINGS, UNIFIED]";
-    qApp->setOverrideCursor(QCursor(Qt::WaitCursor));
     _dataType = type;
-    int reloadInMin = Settings::downloadInterval();
+    int reloadInSec = Settings::downloadInterval();
     QJsonDocument data = QJsonDocument::fromJson(*bytes);
     if (data.isNull()) {
         qDebug() << "Couldn't parse JSON";
@@ -130,10 +129,9 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type)
         updateEarliest = QDateTime::currentDateTime().addSecs(15);
     }
     // set the earliest time the server will have new data
-    if (whazzupTime.isValid() && reloadInMin > 0) {
-        updateEarliest = whazzupTime.addSecs(reloadInMin * 60).toUTC();
+    if (whazzupTime.isValid() && reloadInSec > 0) {
+        updateEarliest = whazzupTime.addSecs(reloadInSec).toUTC();
     }
-    qApp->restoreOverrideCursor();
     qDebug() << "WhazzupData::WhazzupData(buffer) -- finished";
 }
 
@@ -143,7 +141,6 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data)
       updateEarliest(QDateTime()), whazzupTime(QDateTime()),
       bookingsTime(QDateTime()), predictionBasedOnTime(QDateTime()),
       predictionBasedOnBookingsTime(QDateTime()) {
-    qApp->setOverrideCursor(QCursor(Qt::WaitCursor));
     qDebug() << "WhazzupData::WhazzupData(predictTime)" << predictTime;
 
     whazzupTime = predictTime;
@@ -190,7 +187,7 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data)
     // let controllers be in until he states in his Controller Info also if only found in Whazzup, not booked
     foreach (const Controller* c, data.controllers) {
         // standard for online controllers: 4 min
-        QDateTime showUntil = predictionBasedOnTime.addSecs(Settings::downloadInterval() * 4 * 60);
+        QDateTime showUntil = predictionBasedOnTime.addSecs(4 * 60);
         if (c->assumeOnlineUntil.isValid()) {
             // only if before stated leave-time
             if (predictionBasedOnTime.secsTo(c->assumeOnlineUntil) >= 0) {
@@ -285,7 +282,6 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data)
 
         pilots[np->callsign] = np;
     }
-    qApp->restoreOverrideCursor();
     qDebug() << "WhazzupData::WhazzupData(predictTime) -- finished";
 }
 

--- a/src/dialogs/PreferencesDialog.ui
+++ b/src/dialogs/PreferencesDialog.ui
@@ -134,10 +134,16 @@ location</string>
             <item>
              <widget class="QSpinBox" name="spinBoxDownloadInterval">
               <property name="suffix">
-               <string> min</string>
+               <string>s</string>
               </property>
               <property name="minimum">
-               <number>1</number>
+               <number>15</number>
+              </property>
+              <property name="maximum">
+               <number>300</number>
+              </property>
+              <property name="singleStep">
+               <number>15</number>
               </property>
              </widget>
             </item>

--- a/src/dialogs/Window.cpp
+++ b/src/dialogs/Window.cpp
@@ -146,7 +146,7 @@ Window::Window(QWidget* parent)
     connect(&_timerMetar, &QTimer::timeout, this, &Window::updateMetars);
 
     // Whazzup download timer
-    connect(&_timerWhazzup, &QTimer::timeout, this, &Window::downloadWatchdogTriggered);
+    connect(&_timerWatchdog, &QTimer::timeout, this, &Window::downloadWatchdogTriggered);
 
     // dock layout
     connect(
@@ -267,15 +267,15 @@ void Window::processWhazzup(bool isNew) {
     const WhazzupData &realdata = Whazzup::instance()->realWhazzupData();
     const WhazzupData &data = Whazzup::instance()->whazzupData();
 
-    QString msg = QString(tr("%1%2 - %3: %4 clients"))
+    QString msg = QString(tr("%1%2 – %3: %4 clients"))
         .arg(
         Settings::downloadNetworkName(),
         Whazzup::instance()->predictedTime.isValid()? " - <b>W A R P E D</b>  to": ""
         )
         .arg(
         data.whazzupTime.date() == QDateTime::currentDateTimeUtc().date() // is today?
-            ? QString("today %1").arg(data.whazzupTime.time().toString("HHmm'z'"))
-            : data.whazzupTime.toString("ddd MM/dd HHmm'z'")
+            ? QString("today %1").arg(data.whazzupTime.time().toString("HH:mm:ss'z'"))
+            : data.whazzupTime.toString("ddd MM/dd HH:mm:ss'z'")
         )
         .arg(data.pilots.size() + data.controllers.size());
     GuiMessages::status(msg, "status");
@@ -283,15 +283,15 @@ void Window::processWhazzup(bool isNew) {
     msg = QString("Whazzup %1, bookings %2 updated")
         .arg(
         realdata.whazzupTime.date() == QDateTime::currentDateTimeUtc().date() // is today?
-                ? QString("today %1").arg(realdata.whazzupTime.time().toString("HHmm'z'"))
+                ? QString("today %1").arg(realdata.whazzupTime.time().toString("HH:mm:ss'z'"))
                 : (realdata.whazzupTime.isValid()
-                   ? realdata.whazzupTime.toString("ddd MM/dd HHmm'z'")
+                   ? realdata.whazzupTime.toString("ddd MM/dd HH:mm:ss'z'")
                    : "never"
         ),
         realdata.bookingsTime.date() == QDateTime::currentDateTimeUtc().date() // is today?
-                ? QString("today %1").arg(realdata.bookingsTime.time().toString("HHmm'z'"))
+                ? QString("today %1").arg(realdata.bookingsTime.time().toString("HH:mm:ss'z'"))
                 : (realdata.bookingsTime.isValid()
-                   ? realdata.bookingsTime.toString("ddd MM/dd HHmm'z'")
+                   ? realdata.bookingsTime.toString("ddd MM/dd HH:mm:ss'z'")
                    : "never"
                 )
         );
@@ -359,9 +359,9 @@ void Window::processWhazzup(bool isNew) {
 
         refreshFriends();
     }
-    _timerWhazzup.stop();
+    _timerWatchdog.stop();
     if (Settings::downloadPeriodically()) {
-        _timerWhazzup.start(Settings::downloadInterval() * 60 * 1000 * 4);
+        _timerWatchdog.start(Settings::downloadInterval() * 1000 * 4);
     }
 
     qDebug() << "Window::whazzupDownloaded() -- finished";
@@ -555,7 +555,7 @@ void Window::updateTitlebarAfterMove(Qt::DockWidgetArea area, QDockWidget* dock)
 }
 
 void Window::downloadWatchdogTriggered() {
-    _timerWhazzup.stop();
+    _timerWatchdog.stop();
     Whazzup::instance()->setStatusLocation(Settings::statusLocation());
     GuiMessages::errorUserAttention(
         "Failed to download network data for a while. "

--- a/src/dialogs/Window.h
+++ b/src/dialogs/Window.h
@@ -87,7 +87,7 @@ class Window
         void updateTitlebarAfterMove(Qt::DockWidgetArea, QDockWidget* dock);
 
         SearchResultModel _modelSearchResult, _modelFriends;
-        QTimer _timerSearch, _timerMetar, _timerEditPredict, _timerRunPredict, _timerWhazzup;
+        QTimer _timerSearch, _timerMetar, _timerEditPredict, _timerRunPredict, _timerWatchdog;
         QSortFilterProxyModel* _sortmodelMetar, * _sortmodelFriends;
         MetarModel _metarModel;
         QDateTime _dateTimePredict_old;


### PR DESCRIPTION
The Whazzup status interval restriction has been lifted by the VATSIM IT.

Notice though that hovered labels and selection lists (when clicked near multiple obects) might close when a Whazzup update has just arrived. Avoiding that will need some more work.

I still suggest a download interval of 1 min.