### PR TITLE
[TASK] Simplify logging to stdout (dev)

### DIFF
--- a/QuteScoop.pro
+++ b/QuteScoop.pro
@@ -23,6 +23,7 @@ CONFIG += c++2a
 TEMPLATE = app
 CONFIG *= qt
 
+DEFINES += QT_MESSAGELOGCONTEXT
 CONFIG *= warn_on
 TARGET = QuteScoop
 

--- a/src/Airac.cpp
+++ b/src/Airac.cpp
@@ -38,7 +38,7 @@ Airac::~Airac() {
 }
 
 void Airac::load() {
-    qDebug() << "Airac::load()" << Settings::navdataDirectory();
+    qDebug() << Settings::navdataDirectory();
     GuiMessages::status("Loading navigation database...", "airacload");
     if (Settings::useNavdata()) {
         readFixes(Settings::navdataDirectory());
@@ -61,7 +61,6 @@ void Airac::load() {
 
     GuiMessages::remove("airacload");
     emit loaded();
-    qDebug() << "Airac::load() -- finished";
 }
 
 void Airac::readFixes(const QString& directory) {
@@ -167,8 +166,10 @@ void Airac::readAirways(const QString& directory) {
     }
 
     bool ok;
+    unsigned int count = 0;
     int segments = 0;
     while (!fr.atEnd()) {
+        ++count;
         QString line = fr.nextLine().trimmed();
         // file format:
         // EXOLU VA 11 TAXUN VA 11 N 2  75 460 B342-N519-W14
@@ -185,7 +186,8 @@ void Airac::readAirways(const QString& directory) {
 
         QStringList list = line.split(' ', Qt::SkipEmptyParts);
         if (list.size() != 11) {
-            qCritical() << "Airac::readAirways() not exactly 11 fields:" << list;
+            QMessageLogger(file.toLocal8Bit(), count, QT_MESSAGELOG_FUNC).critical()
+                << "not exactly 11 fields:" << list;
             continue;
         }
 
@@ -193,12 +195,14 @@ void Airac::readAirways(const QString& directory) {
         QString regionCode = list[1];
         int fixType = list[2].toInt(&ok);
         if (!ok) {
-            qCritical() << "Airac::readAirways() unable to parse fix type (int):" << list;
+            QMessageLogger(file.toLocal8Bit(), count, QT_MESSAGELOG_FUNC).critical()
+                << "unable to parse fix type (int):" << list;
             continue;
         }
         Waypoint* start = waypoint(id, regionCode, fixType);
         if (start == 0) {
-            qCritical() << "Airac::readAirways() unable to find start waypoint:" << QStringList{ id, regionCode, QString::number(fixType) } << list;
+            QMessageLogger(file.toLocal8Bit(), count, QT_MESSAGELOG_FUNC).critical()
+                << "unable to find start waypoint:" << QStringList{ id, regionCode, QString::number(fixType) } << list;
             continue;
         }
 
@@ -206,12 +210,14 @@ void Airac::readAirways(const QString& directory) {
         regionCode = list[4];
         fixType = list[5].toInt(&ok);
         if (!ok) {
-            qCritical() << "Airac::readAirways() unable to parse fix type (int):" << list;
+            QMessageLogger(file.toLocal8Bit(), count, QT_MESSAGELOG_FUNC).critical()
+                << "unable to parse fix type (int):" << list;
             continue;
         }
         Waypoint* end = waypoint(id, regionCode, fixType);
         if (end == 0) {
-            qCritical() << "Airac::readAirways() unable to find end waypoint:" << QStringList{ id, regionCode, QString::number(fixType) } << list;
+            QMessageLogger(file.toLocal8Bit(), count, QT_MESSAGELOG_FUNC).critical()
+                << "unable to find start waypoint:" << QStringList{ id, regionCode, QString::number(fixType) } << list;
             continue;
         }
 
@@ -419,7 +425,6 @@ void Airac::addAirwaySegment(Waypoint* from, Waypoint* to, const QString& name) 
  * Unknown fixes and/or airways will be ignored.
  **/
 QList<Waypoint*> Airac::resolveFlightplan(QStringList plan, double lat, double lon) {
-    //qDebug() << "Airac::resolveFlightPlan()" << plan;
     QList<Waypoint*> result;
     Waypoint* currPoint = 0;
     Airway* awy = 0;

--- a/src/Airport.cpp
+++ b/src/Airport.cpp
@@ -88,10 +88,8 @@ Airport::Airport(const QStringList& list, unsigned int debugLineNumber)
     resetWhazzupStatus();
 
     if (list.size() != 6) {
-        auto msg = QString("While processing line #%1 '%2' from data/airports.dat: Found %3 fields, expected exactly 6.")
-            .arg(debugLineNumber).arg(list.join(':')).arg(list.size());
-        qCritical() << "Airport::Airport()" << msg;
-        QTextStream(stdout) << "CRITICAL: " << msg << Qt::endl;
+        QMessageLogger("airports.dat", debugLineNumber, QT_MESSAGELOG_FUNC).critical()
+            << "While processing line" << list.join(':') << ": Found" << list.size() << "fields, expected exactly 6.";
         exit(EXIT_FAILURE);
     }
 
@@ -101,11 +99,8 @@ Airport::Airport(const QStringList& list, unsigned int debugLineNumber)
     countryCode = list[3];
 
     if (countryCode != "" && NavData::instance()->countryCodes.value(countryCode, "") == "") {
-        auto msg = QString("While processing line #%1 from data/airports.dat: Could not find country '%2' for airport %3 (%4, %5) in data/countryCodes.dat.")
-            .arg(debugLineNumber)
-            .arg(countryCode, id, name, city);
-        qCritical() << "Airport::Airport()" << msg;
-        QTextStream(stdout) << "CRITICAL: " << msg << Qt::endl;
+        QMessageLogger("airports.dat", debugLineNumber, QT_MESSAGELOG_FUNC).critical()
+            << "While processing line" << list.join(':') << ": Could not find country" << countryCode;
         exit(EXIT_FAILURE);
     }
 

--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -249,7 +249,7 @@ const QPair<double, double> GLWidget::sunZenith(const QDateTime &dateTime) const
 // Methods preparing displayLists
 //
 void GLWidget::createPilotsList() {
-    qDebug() << "GLWidget::createPilotsList()";
+    qDebug();
 
     if (_pilotsList == 0) {
         _pilotsList = glGenLists(1);
@@ -460,11 +460,11 @@ void GLWidget::createPilotsList() {
         glEndList();
     }
 
-    qDebug() << "GLWidget::createPilotsList() -- finished";
+    qDebug() << "-- finished";
 }
 
 void GLWidget::createAirportsList() {
-    qDebug() << "GLWidget::createAirportsList() ";
+    qDebug();
     if (_activeAirportsList == 0) {
         _activeAirportsList = glGenLists(1);
     }
@@ -553,11 +553,11 @@ void GLWidget::createAirportsList() {
         }
     }
     glEndList();
-    qDebug() << "GLWidget::createAirportsList() -- finished";
+    qDebug() << "-- finished";
 }
 
 void GLWidget::createControllerLists() {
-    qDebug() << "GLWidget::createControllersLists() ";
+    qDebug();
 
     // FIR polygons
     if (_sectorPolygonsList == 0) {
@@ -602,7 +602,7 @@ void GLWidget::createControllerLists() {
         }
         glEndList();
     }
-    qDebug() << "GLWidget::createControllersLists() -- finished";
+    qDebug() << "-- finished";
 }
 
 
@@ -683,9 +683,8 @@ void GLWidget::createHoveredControllersLists(QSet<Controller*> controllers) {
 
 void GLWidget::createStaticLists() {
     // earth
-    qDebug() << "GLWidget::createStaticLists() earth";
-    _earthQuad = gluNewQuadric();
     qDebug() << "Generating quadric texture coordinates";
+    _earthQuad = gluNewQuadric();
     gluQuadricTexture(_earthQuad, GL_TRUE); // prepare texture coordinates
     gluQuadricDrawStyle(_earthQuad, GLU_FILL); // FILL, LINE, SILHOUETTE or POINT
     gluQuadricNormals(_earthQuad, GLU_SMOOTH); // NONE, FLAT or SMOOTH
@@ -741,7 +740,7 @@ void GLWidget::createStaticLists() {
     glEndList();
 
     // grid
-    qDebug() << "GLWidget::createStaticLists() gridLines";
+    qDebug() << "gridLines";
     _gridlinesList = glGenLists(1);
     glNewList(_gridlinesList, GL_COMPILE);
     if (!qFuzzyIsNull(Settings::gridLineStrength())) {
@@ -770,7 +769,7 @@ void GLWidget::createStaticLists() {
     glEndList();
 
     // coastlines
-    qDebug() << "GLWidget::createStaticLists() coastLines";
+    qDebug() << "coastLines";
     _coastlinesList = glGenLists(1);
     glNewList(_coastlinesList, GL_COMPILE);
     if (!qFuzzyIsNull(Settings::coastLineStrength())) {
@@ -790,7 +789,7 @@ void GLWidget::createStaticLists() {
     glEndList();
 
     // countries
-    qDebug() << "GLWidget::createStaticLists() countries";
+    qDebug() << "countries";
     _countriesList = glGenLists(1);
     glNewList(_countriesList, GL_COMPILE);
     if (!qFuzzyIsNull(Settings::countryLineStrength())) {
@@ -861,7 +860,6 @@ void GLWidget::createStaticSectorLists() {
  * Call drawCoordinateAxii() inside paintGL() to see where the axii are.
  **/
 void GLWidget::initializeGL() {
-    qDebug() << "GLWidget::initializeGL()";
     qDebug() << "OpenGL support: " << context()->format().hasOpenGL()
              << "; 1.1:" << format().openGLVersionFlags().testFlag(QGLFormat::OpenGL_Version_1_1)
              << "; 1.2:" << format().openGLVersionFlags().testFlag(QGLFormat::OpenGL_Version_1_2)
@@ -1037,7 +1035,7 @@ void GLWidget::initializeGL() {
     }
 
     createStaticLists();
-    qDebug() << "GLWidget::initializeGL() -- finished";
+    qDebug() << "-- finished";
 }
 
 /**
@@ -1417,7 +1415,6 @@ void GLWidget::mouseReleaseEvent(QMouseEvent* event) {
 }
 
 void GLWidget::rightClick(const QPoint& pos) {
-    qDebug() << "GLWidget::rightClick()";
     auto objects = objectsAt(pos.x(), pos.y());
     int countRelevant = 0;
     Pilot* pilot = 0;
@@ -1462,7 +1459,6 @@ void GLWidget::rightClick(const QPoint& pos) {
         }
         invalidatePilots();
     }
-    qDebug() << "GLWidget::rightClick() -- finished";
 }
 
 void GLWidget::mouseDoubleClickEvent(QMouseEvent* event) {
@@ -1538,7 +1534,7 @@ void GLWidget::renderLabels() {
 
     // sector controller labels
     if (m_isControllerMapObjectsDirty) {
-        qDebug() << "GLWidget::renderLabels building controllerMapObjects";
+        qDebug() << "building controllerMapObjects";
         m_controllerMapObjects.clear();
 
         foreach (Controller* c, Whazzup::instance()->whazzupData().controllers) {
@@ -1567,7 +1563,7 @@ void GLWidget::renderLabels() {
 
     // airport labels
     if (m_isAirportsMapObjectsDirty) {
-        qDebug() << "GLWidget::renderLabels building airportMapObjects";
+        qDebug() << "building airportMapObjects";
 
         m_activeAirportMapObjects.clear();
         const QList<Airport*> activeAirportsSorted = NavData::instance()->activeAirports.values();
@@ -1591,7 +1587,7 @@ void GLWidget::renderLabels() {
 
     // pilot labels
     if (m_isPilotMapObjectsDirty) {
-        qDebug() << "GLWidget::renderLabels building pilotMapObjects";
+        qDebug() << "building pilotMapObjects";
         m_pilotMapObjects.clear();
 
         const QList<Pilot*> pilots = Whazzup::instance()->whazzupData().allPilots();
@@ -2353,7 +2349,7 @@ void GLWidget::drawCoordinateAxiiCurrentMatrix() const {
 /////////////////////////
 
 void GLWidget::newWhazzupData(bool isNew) {
-    qDebug() << "GLWidget::newWhazzupData() isNew =" << isNew;
+    qDebug() << "isNew =" << isNew;
     if (isNew) {
         // update airports
         NavData::instance()->updateData(Whazzup::instance()->whazzupData());
@@ -2365,7 +2361,7 @@ void GLWidget::newWhazzupData(bool isNew) {
         invalidateAirports();
         m_friendPositions = Whazzup::instance()->whazzupData().friendsLatLon();
     }
-    qDebug() << "GLWidget::newWhazzupData -- finished";
+    qDebug() << "-- finished";
 }
 
 void GLWidget::createFriendHighlighter() {
@@ -2393,14 +2389,14 @@ void GLWidget::destroyFriendHighlighter() {
 //////////////////////////////////
 
 void GLWidget::parseTexture() {
-    qDebug() << "GLWidget::parseTexture()";
+    qDebug();
     GuiMessages::progress("textures", "Preparing textures...");
 
     QImage earthTexIm;
 
     if (Settings::glTextures()) {
         QString earthTexFile = Settings::dataDirectory(QString("textures/%1").arg(Settings::glTextureEarth()));
-        qDebug() << "GLWidget::parseTexture() loading earth texture";
+        qDebug() << "loading earth texture";
         GuiMessages::progress("textures", "Preparing textures: loading earth...");
         earthTexIm.load(earthTexFile);
     }
@@ -2437,7 +2433,7 @@ void GLWidget::parseTexture() {
         }
     }
 
-    qDebug() << "GLWidget::parseTexture() finished";
+    qDebug() << "-- finished";
     update();
     GuiMessages::remove("textures");
 }

--- a/src/GuiMessage.cpp
+++ b/src/GuiMessage.cpp
@@ -81,14 +81,12 @@ void GuiMessages::remove(const QString &id) {
 ///////////////////////////////////////////////////////////////////////////
 // METHODS TO SET ACTIVE OUTPUT WIDGETS
 void GuiMessages::addStatusLabel(QLabel* label, bool hideIfNothingToDisplay) {
-    //qDebug() << "GuiMessages::addStatusLabel()" << label->objectName();
     // we want to be notified before this QLabel is getting invalid
     connect(label, &QObject::destroyed, this, &GuiMessages::labelDestroyed);
     _labels.insert(label, hideIfNothingToDisplay);
     update();
 }
 void GuiMessages::removeStatusLabel(QLabel* label) {
-    //qDebug() << "GuiMessages::removeStatusLabel()" << label->objectName();
     if (_labels[label]) {
         label->hide();
     }
@@ -97,37 +95,30 @@ void GuiMessages::removeStatusLabel(QLabel* label) {
 void GuiMessages::labelDestroyed(QObject* obj) {
     if (static_cast<QLabel*>(obj) != 0) {
         if (_labels.remove(static_cast<QLabel*>(obj)) == 0) {
-            qWarning() << "GuiMessages::labelDestroyed() object not found";
+            qWarning() << "object not found";
         }
-        // else
-        //    qDebug() << "GuiMessages::labelDestroyed() removed object";
     } else {
-        qWarning() << "GuiMessages::labelDestroyed() invalid object cast";
+        qWarning() << "invalid object cast";
     }
 }
 
 void GuiMessages::addProgressBar(QProgressBar* progressBar, bool hideIfNothingToDisplay) {
-    //qDebug() << "GuiMessages::addProgressBar()" << progressBar->objectName();
     // we want to be notified before this QProgressBar is getting invalid
     connect(progressBar, &QObject::destroyed, this, &GuiMessages::progressBarDestroyed);
     _bars.insert(progressBar, hideIfNothingToDisplay);
     update();
 }
 void GuiMessages::removeProgressBar(QProgressBar* progressBar) {
-    //qDebug() << "GuiMessages::removeProgressBar()" << progressBar->objectName();
     if (_bars[progressBar]) {
         progressBar->hide();
     }
     _bars.remove(progressBar);
 }
 void GuiMessages::progressBarDestroyed(QObject* obj) {
-    // qDebug() << obj;
     if (static_cast<QProgressBar*>(obj) != 0) {
         if (_bars.remove(static_cast<QProgressBar*>(obj)) == 0) {
             qWarning() << "GuiMessages::progressBarDestroyed() object not found";
         }
-        // else
-        //    qDebug() << "GuiMessages::progressBarDestroyed() removed object";
     } else {
         qWarning() << "GuiMessages::progressBarDestroyed() invalid object cast";
     }
@@ -136,7 +127,6 @@ void GuiMessages::progressBarDestroyed(QObject* obj) {
 ///////////////////////////////////////////////////////////////////////////
 // INTERNALLY USED CLASS AND METHODS (called by static methods)
 void GuiMessages::updateMessage(GuiMessage* gm) {
-    //qDebug() << "GuiMessages::updateMessage()" << guiMessage;
     GuiMessage* existing = messageById(gm->id, gm->type);
     if (existing != 0) {
         if (!gm->msg.isEmpty()) {
@@ -154,15 +144,12 @@ void GuiMessages::updateMessage(GuiMessage* gm) {
         if (gm->shownSince.isValid()) {
             existing->shownSince = gm->shownSince;
         }
-        // qDebug() << " updated existing message:" << existing;
     } else {
-        // qDebug() << "GuiMessage()::updateMessage() new" << gm;
         _messages.insert(gm->type, gm);
     }
     update();
 }
 void GuiMessages::removeMessageById(const QString &id) {
-    // qDebug() << "GuiMessages::removeMessage() id=" << id;
     foreach (int key, _messages.keys()) {
         foreach (GuiMessage* gm, _messages.values(key)) {
             if (gm->id == id) {
@@ -172,8 +159,6 @@ void GuiMessages::removeMessageById(const QString &id) {
                 if (_currentProgressMessage == gm) {
                     setProgress(new GuiMessage());
                 }
-                // qDebug() << "GuiMessage()::removeMessageById() removed"
-                //         << gm;
                 _messages.remove(key, gm);
             }
         }
@@ -184,7 +169,6 @@ void GuiMessages::removeMessageById(const QString &id) {
 ///////////////////////////////////////////////////////////////////////////
 // PRIVATE METHODS
 void GuiMessages::setStatusMessage(GuiMessage* gm, bool, bool, bool instantRepaint) {
-    //qDebug() << "GuiMessages::setStatusMessage()" << gm;
     foreach (QLabel* l, _labels.keys()) {
         l->setText(gm->msg);
         if (_labels[l]) { // bool indicating hideIfNothingToDisplay
@@ -202,7 +186,6 @@ void GuiMessages::setStatusMessage(GuiMessage* gm, bool, bool, bool instantRepai
     }
 }
 void GuiMessages::setProgress(GuiMessage* gm, bool instantRepaint) {
-    //qDebug() << "GuiMessages::setProgress()" << gm;
     foreach (QProgressBar* pb, _bars.keys()) {
         if (gm->progressMaximum != -1) {
             pb->setMaximum(gm->progressMaximum);
@@ -222,11 +205,8 @@ void GuiMessages::setProgress(GuiMessage* gm, bool instantRepaint) {
 }
 
 void GuiMessages::update() {
-    //qDebug() << "GuiMessages::update() now=" << QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
     foreach (int key, _messages.keys()) {
         foreach (GuiMessage* gm, _messages.values(key)) {
-            //qDebug() << " " << gm;
-
             if (
                 gm->showMs != -1 && gm->shownSince.isValid() // shown long enough
                 && gm->shownSince.addMSecs(gm->showMs)
@@ -286,7 +266,6 @@ void GuiMessages::update() {
             }
         }
     }
-    //qDebug() << "GuiMessages::update() --finished";
 }
 
 GuiMessages::GuiMessage* GuiMessages::messageById(const QString &id, const GuiMessage::Type &type) {

--- a/src/LineReader.cpp
+++ b/src/LineReader.cpp
@@ -22,12 +22,12 @@ const QList<QPair<double, double> >& LineReader::readLine() {
         bool ok = true;
         double lat = list[0].toDouble(&ok);
         if (!ok) {
-            qWarning() << "LineReader::readLine() unable to read lat (double):" << list;
+            qWarning() << "unable to read lat (double):" << list;
             continue;
         }
         double lon = list[1].toDouble(&ok);
         if (!ok) {
-            qWarning() << "LineReader::readLine() unable to read lon (double):" << list;
+            qWarning() << "unable to read lon (double):" << list;
             continue;
         }
 

--- a/src/MapScreen.cpp
+++ b/src/MapScreen.cpp
@@ -55,14 +55,14 @@ MapScreen::MapScreen(QWidget* parent)
     fmt.setSampleBuffers(sampleBuffers);
 
 
-    qDebug() << "MapScreen::MapScreen() creating GLWidget";
+    qDebug() << "creating GLWidget";
     glWidget = new GLWidget(fmt, this);
     QGridLayout* layout = new QGridLayout;
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setMargin(0);
     layout->addWidget(glWidget);
     setLayout(layout);
-    qDebug() << "MapScreen::MapScreen() creating GLWidget --finished";
+    qDebug() << "creating GLWidget --finished";
 }
 
 void MapScreen::resizeEvent(QResizeEvent*) {

--- a/src/Metar.cpp
+++ b/src/Metar.cpp
@@ -26,7 +26,7 @@ bool Metar::doesNotExist() const {
 bool Metar::needsRefresh() const {
     const int ageSec = downloaded.secsTo(QDateTime::currentDateTime());
     const bool ret = isNull() || ageSec > Settings::metarDownloadInterval() * 60;
-    qDebug() << "Metar::needsRefresh()" << airportLabel << QString("age: %1").arg(ageSec) << "=>" << ret;
+    qDebug() << airportLabel << QString("age: %1").arg(ageSec) << "=>" << ret;
     return ret;
 }
 
@@ -132,7 +132,7 @@ QString Metar::decodeVisibility(QStringList& tokens) const {
     bool ok;
     int i = vis.toInt(&ok);
     if (!ok) {
-        qWarning() << "Metar::decodeVisibility() unable to parse vis (int):" << vis;
+        qWarning() << "unable to parse vis (int):" << vis;
         return QString();
     }
 

--- a/src/NavAid.cpp
+++ b/src/NavAid.cpp
@@ -2,7 +2,8 @@
 
 NavAid::NavAid(const QStringList&stringList) {
     if (stringList.size() < 12) {
-        qCritical() << "NavAid(): could not parse " << stringList << " as Navaid. Expected more than 12 fields.";
+        QMessageLogger("earth_nav.dat", 0, QT_MESSAGELOG_FUNC).critical()
+            << "could not parse" << stringList << "as Navaid. Expected more than 12 fields.";
         return;
     }
 
@@ -10,23 +11,27 @@ NavAid::NavAid(const QStringList&stringList) {
 
     _type = (Type) stringList[0].toInt(&ok);
     if (!ok) {
-        qCritical() << "NavAid::NavAid() unable to parse waypointtype (int):" << stringList << 0;
+        QMessageLogger("earth_nav.dat", 0, QT_MESSAGELOG_FUNC).critical()
+            << "unable to parse waypointtype (int):" << stringList;
         return;
     }
     lat = stringList[1].toDouble(&ok);
     if (!ok) {
-        qCritical() << "NavAid::NavAid() unable to parse lat (double):" << stringList << 1;
+        QMessageLogger("earth_nav.dat", 0, QT_MESSAGELOG_FUNC).critical()
+            << "unable to parse lat (double):" << stringList;
         return;
     }
     lon = stringList[2].toDouble(&ok);
     if (!ok) {
-        qCritical() << "NavAid::NavAid() unable to parse lon (double):" << stringList << 2;
+        QMessageLogger("earth_nav.dat", 0, QT_MESSAGELOG_FUNC).critical()
+            << "unable to parse lon (double):" << stringList;
         return;
     }
 
     _freq = stringList[4].toInt(&ok);
     if (!ok) {
-        qCritical() << "NavAid::NavAid() unable to parse frequency (int):" << stringList << 4;
+        QMessageLogger("earth_nav.dat", 0, QT_MESSAGELOG_FUNC).critical()
+            << "unable to parse freq (int):" << stringList;
         return;
     }
 

--- a/src/NavData.cpp
+++ b/src/NavData.cpp
@@ -66,17 +66,16 @@ void NavData::loadAirports(const QString& filename) {
     }
 
     if (countMissingCountry != 0) {
-        auto msg = QString("%1 airports are missing a country code. Please help by adding them in data/airports.dat.")
-            .arg(countMissingCountry);
-        qWarning() << "NavData::loadAirports()" << msg;
-        QTextStream(stdout) << "WARNING: " << msg << Qt::endl;
+        qWarning() << countMissingCountry << "airports are missing a country code. Please help by adding them in data/airports.dat.";
     }
 }
 
 void NavData::loadControllerAirportsMapping(const QString &filePath) {
     m_controllerAirportsMapping.clear();
     FileReader fr(filePath);
+    unsigned int count = 0;
     while (!fr.atEnd()) {
+        ++count;
         QString _line = fr.nextLine().trimmed();
 
         if (_line.isEmpty() || _line.startsWith(";")) {
@@ -85,10 +84,8 @@ void NavData::loadControllerAirportsMapping(const QString &filePath) {
 
         QStringList _fields = _line.split(':');
         if (_fields.size() != 3) {
-            auto msg = QString("Could not load line '%1' (%2 fields) from %3")
-                .arg(_line).arg(_fields.count()).arg(filePath);
-            qCritical() << "NavData::loadControllerAirportsMapping()" << msg;
-            QTextStream(stdout) << "CRITICAL: " << msg << Qt::endl;
+            QMessageLogger(filePath.toLocal8Bit(), count, QT_MESSAGELOG_FUNC).critical()
+                << _line << ": Expected 3 fields";
             exit(EXIT_FAILURE);
         }
 
@@ -99,10 +96,8 @@ void NavData::loadControllerAirportsMapping(const QString &filePath) {
             if (airports.contains(_airportIcao)) {
                 _cam.airports.insert(airports.value(_airportIcao));
             } else {
-                auto msg = QString("While processing line '%1' from %2: Airport '%3' not found.")
-                    .arg(_line, filePath, _airportIcao);
-                qCritical() << "NavData::loadControllerAirportsMapping()" << msg;
-                QTextStream(stdout) << "CRITICAL: " << msg << Qt::endl;
+                QMessageLogger(filePath.toLocal8Bit(), count, QT_MESSAGELOG_FUNC).critical()
+                    << _line << ": Airport" << _airportIcao << "not found in airports.dat";
                 exit(EXIT_FAILURE);
             }
         }
@@ -114,7 +109,9 @@ void NavData::loadControllerAirportsMapping(const QString &filePath) {
 void NavData::loadCountryCodes(const QString& filePath) {
     countryCodes.clear();
     FileReader fr(filePath);
+    unsigned int count = 0;
     while (!fr.atEnd()) {
+        ++count;
         QString _line = fr.nextLine().trimmed();
 
         if (_line.isEmpty() || _line.startsWith(";")) {
@@ -123,10 +120,8 @@ void NavData::loadCountryCodes(const QString& filePath) {
 
         QStringList _fields = _line.split(':');
         if (_fields.size() != 2) {
-            auto msg = QString("Could not load line '%1' (%2 fields) from %3")
-                .arg(_line).arg(_fields.count()).arg(filePath);
-            qCritical() << "NavData::loadCountryCodes()" << msg;
-            QTextStream(stdout) << "CRITICAL: " << msg << Qt::endl;
+            QMessageLogger(filePath.toLocal8Bit(), count, QT_MESSAGELOG_FUNC).critical()
+                << _line << ": Expected 2 fields";
             exit(EXIT_FAILURE);
         }
         countryCodes[_fields.first()] = _fields.last();
@@ -143,10 +138,6 @@ void NavData::loadAirlineCodes(const QString &filePath) {
         delete _a;
     }
     airlines.clear();
-    if (filePath.isEmpty()) {
-        qWarning() << "NavData::loadAirlineCodes() -- bad filename";
-        return;
-    }
 
     auto count = 0;
     FileReader fr(filePath);
@@ -159,10 +150,8 @@ void NavData::loadAirlineCodes(const QString &filePath) {
 
         QStringList _fields = _line.split(0x09); // 0x09 code for Tabulator
         if (_fields.count() != 4) {
-            auto msg = QString("Could not load line '%1' (%2 fields) from %3")
-                .arg(_line).arg(_fields.count()).arg(filePath);
-            qCritical() << "NavData::loadAirlineCodes()" << msg;
-            QTextStream(stdout) << "CRITICAL: " << msg << Qt::endl;
+            QMessageLogger(filePath.toLocal8Bit(), count, QT_MESSAGELOG_FUNC).critical()
+                << _line << ": Expected 4 fields";
             exit(EXIT_FAILURE);
         }
 
@@ -223,7 +212,7 @@ QSet<Airport*> NavData::additionalMatchedAirportsForController(QString prefix, Q
 }
 
 void NavData::updateData(const WhazzupData& whazzupData) {
-    qDebug() << "NavData::updateData() on" << airports.size() << "airports";
+    qDebug() << "on" << airports.size() << "airports";
     foreach (Airport* a, activeAirports.values()) {
         a->resetWhazzupStatus();
     }
@@ -279,7 +268,7 @@ void NavData::updateData(const WhazzupData& whazzupData) {
         activeAirports.insert(a->congestion(), a);
     }
 
-    qDebug() << "NavData::updateData() -- finished";
+    qDebug() << "-- finished";
 }
 
 void NavData::accept(SearchVisitor* visitor) {

--- a/src/Pilot.cpp
+++ b/src/Pilot.cpp
@@ -702,7 +702,6 @@ void Pilot::primaryAction() {
 }
 
 QList<Waypoint*> Pilot::routeWaypoints() {
-    //qDebug() << "Pilot::routeWaypoints()" << label;
     if (
         (planDep == routeWaypointsPlanDepCache) // we might have cached the route already
         && (planDest == routeWaypointsPlanDestCache)
@@ -727,7 +726,6 @@ QList<Waypoint*> Pilot::routeWaypoints() {
         routeWaypointsCache = QList<Waypoint*>();
     }
 
-    //qDebug() << "Pilot::routeWaypoints() -- finished" << label;
     return routeWaypointsCache;
 }
 

--- a/src/Ping.cpp
+++ b/src/Ping.cpp
@@ -26,6 +26,6 @@ void Ping::startPing(QString server) {
 #ifdef Q_OS_MAC
     pingArgs << "-c1" << server;
 #endif
-    qDebug() << "Ping::startPing() executing" << "ping" << pingArgs;
+    qDebug() << "executing" << "ping" << pingArgs;
     _pingProcess->start("ping", pingArgs);
 }

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -11,13 +11,8 @@ Sector::Sector(const QStringList &fields, const int debugControllerLineNumber, c
       _debugSectorLineNumber(debugSectorLineNumber) {
     // LSAZ:Zurich::::189[:CTR]
     if (fields.size() != 6 && fields.size() != 7) {
-        auto msg = QString("While processing line #%1 '%2' from %3: Expected 6-7 fields, got %5")
-            .arg(_debugControllerLineNumber)
-            .arg(fields.join(':'))
-            .arg("data/firlist.dat")
-            .arg(fields.count());
-        qCritical() << "NavData::loadCountryCodes()" << msg;
-        QTextStream(stdout) << "CRITICAL: " << msg << Qt::endl;
+        QMessageLogger("firlist.dat", debugControllerLineNumber, QT_MESSAGELOG_FUNC).critical()
+            << fields << ": Expected 6-7 fields";
         exit(EXIT_FAILURE);
     }
 

--- a/src/SectorReader.cpp
+++ b/src/SectorReader.cpp
@@ -63,13 +63,8 @@ void SectorReader::loadSectordisplay(QMultiMap<QString, Sector*>& sectors) {
         if (line.startsWith("DISPLAY_LIST_")) {
             if (!workingSectorId.isEmpty()) { // we are at the end of a section
                 if (pointList.size() < 3) {
-                    auto msg = QString("While processing lines #%1-%2 from %3: Sector %4 doesn't contain enough points (%5, expected 3+)")
-                        .arg(debugLineWorkingSectorStart)
-                        .arg(count)
-                        .arg(filePath, workingSectorId)
-                        .arg(pointList.size());
-                    qCritical() << "SectorReader::loadSectordisplay()" << msg;
-                    QTextStream(stdout) << "CRITICAL: " << msg << Qt::endl;
+                    QMessageLogger(filePath, debugLineWorkingSectorStart, QT_MESSAGELOG_FUNC).critical()
+                        << "Sector" << workingSectorId << "doesn't contain enough points (" << pointList.size() << ", expected 3+)";
                     exit(EXIT_FAILURE);
                 }
 
@@ -81,11 +76,8 @@ void SectorReader::loadSectordisplay(QMultiMap<QString, Sector*>& sectors) {
                 }
 
                 if (sectorsWithMatchingId.size() == 0) {
-                    auto msg = QString("While processing line #%1 '%2' from %3: Sector ID %4 is not used in firlist.dat.")
-                        .arg(count)
-                        .arg(line, filePath)
-                        .arg(workingSectorId);
-                    qInfo() << "SectorReader::loadSectordisplay()" << msg;
+                    QMessageLogger(filePath, count, QT_MESSAGELOG_FUNC).info()
+                        << line << "Sector ID" << workingSectorId << "is not used in firlist.dat.";
 
                     // add this pseudo sector to be able to show it in StaticSectorsDialog
                     auto* s = new Sector(
@@ -125,12 +117,8 @@ void SectorReader::loadSectordisplay(QMultiMap<QString, Sector*>& sectors) {
             double lat = latLng[0].toDouble();
             double lon = Helpers::modPositive(latLng[1].toDouble() + 180., 360.) - 180.;
             if (lat > 90. || lat < -90. || lon > 180. || lon < -180. || (qFuzzyIsNull(lat) && qFuzzyIsNull(lon))) {
-                auto msg = QString("While processing line #%1 '%2' from %3: Sector id=%4 has invalid point %5:%6")
-                    .arg(count)
-                    .arg(line, filePath)
-                    .arg(workingSectorId).arg(lat).arg(lon);
-                qCritical() << "SectorReader::loadSectordisplay()" << msg;
-                QTextStream(stdout) << "CRITICAL: " << msg << Qt::endl;
+                QMessageLogger(filePath, count, QT_MESSAGELOG_FUNC).critical()
+                    << line << ": Sector id" << workingSectorId << "has invalid point" << lat << lon;
                 exit(EXIT_FAILURE);
             }
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -136,7 +136,7 @@ void Settings::migrate(QSettings* settingsInstance) {
 
     foreach (const auto &migration, migrations) {
         if (settingsInstance->value("settings/version", 0).toInt() < migration.version) {
-            qDebug() << QString("Settings::migrate() Migrating to settings version v%1: %2...").arg(migration.version).arg(migration.name);
+            qCritical() << QString("Migrating to settings version v%1: %2...").arg(migration.version).arg(migration.name);
             migration.run();
             settingsInstance->setValue("settings/version", migration.version);
         }

--- a/src/Tessellator.cpp
+++ b/src/Tessellator.cpp
@@ -52,7 +52,7 @@ void Tessellator::tessellate(const QList<QPair<double, double> >& points) {
 }
 
 CALLBACK_DECL Tessellator::tessErrorCB(GLenum errorCode) {
-    qCritical() << "Tessellator::tessErrorCB()" << (char*) gluErrorString(errorCode);
+    qCritical() << (char*) gluErrorString(errorCode);
 }
 
 CALLBACK_DECL Tessellator::tessBeginCB(GLenum which) {

--- a/src/Waypoint.cpp
+++ b/src/Waypoint.cpp
@@ -3,28 +3,31 @@
 #include "Airac.h"
 #include "NavData.h"
 
-Waypoint::Waypoint(const QStringList& stringList)
+Waypoint::Waypoint(const QStringList& fields)
     : MapObject() {
-    if (stringList.size() != 6) {
-        qCritical() << "Waypoint(): could not parse " << stringList << " as Waypoint. Expected 6 fields.";
+    if (fields.size() != 6) {
+        QMessageLogger("earth_fix.dat", 0, QT_MESSAGELOG_FUNC).critical()
+            << fields << ": Expected 6 fields";
         return;
     }
 
     bool ok;
 
-    lat = stringList[0].toDouble(&ok);
+    lat = fields[0].toDouble(&ok);
     if (!ok) {
-        qCritical() << "Waypoint::Waypoint() unable to parse lat:" << stringList;
+        QMessageLogger("earth_fix.dat", 0, QT_MESSAGELOG_FUNC).critical()
+            << fields << ": unable to parse lat";
         return;
     }
-    lon = stringList[1].toDouble(&ok);
+    lon = fields[1].toDouble(&ok);
     if (!ok) {
-        qCritical() << "Waypoint::Waypoint() unable to parse lon:" << stringList;
+        QMessageLogger("earth_fix.dat", 0, QT_MESSAGELOG_FUNC).critical()
+            << fields << ": unable to parse lon";
         return;
     }
-    id = stringList[2];
+    id = fields[2];
 
-    regionCode = stringList[4];
+    regionCode = fields[4];
 }
 
 Waypoint::Waypoint(const QString& id, const double lat, const double lon)

--- a/src/Whazzup.cpp
+++ b/src/Whazzup.cpp
@@ -52,7 +52,7 @@ void Whazzup::setStatusLocation(const QString& statusLocation) {
 }
 
 void Whazzup::processStatus() {
-    qDebug() << "Whazzup::processStatus()";
+    qDebug();
     disconnect(_replyStatus, &QNetworkReply::finished, this, &Whazzup::processStatus);
 
     // status.vatsim.net uses redirection
@@ -60,7 +60,7 @@ void Whazzup::processStatus() {
         QNetworkRequest::RedirectionTargetAttribute
     ).toUrl();
     if (!urlRedirect.isEmpty() && urlRedirect != _replyStatus->url()) {
-        qDebug() << "Whazzup::processStatus() redirected to" << urlRedirect;
+        qDebug() << "redirected to" << urlRedirect;
         // send new request
         if (_replyStatus != 0) {
             delete _replyStatus;
@@ -118,9 +118,9 @@ void Whazzup::processStatus() {
     _lastDownloadTime = QTime();
 
     GuiMessages::remove("statusdownload");
-    qDebug() << "Whazzup::statusDownloaded() data.v3[]:" << _json3Urls;
-    qDebug() << "Whazzup::statusDownloaded() metar.0:" << _metar0Url;
-    qDebug() << "Whazzup::statusDownloaded() user.0:" << _user0Url;
+    qDebug() << "data.v3[]:" << _json3Urls;
+    qDebug() << "metar.0:" << _metar0Url;
+    qDebug() << "user.0:" << _user0Url;
 
     if (_json3Urls.size() == 0) {
         GuiMessages::warning("No Whazzup-URLs found. Try again later.");
@@ -130,7 +130,7 @@ void Whazzup::processStatus() {
 }
 
 void Whazzup::fromFile(QString filename) {
-    qDebug() << "Whazzup::fromFile()" << filename;
+    qDebug() << filename;
     GuiMessages::progress("whazzupDownload", "Loading Whazzup from file...");
 
     if (_replyWhazzup != 0) {
@@ -217,7 +217,7 @@ void Whazzup::processWhazzup() {
 
         if (newWhazzupData.whazzupTime != _data.whazzupTime) {
             _data.updateFrom(newWhazzupData);
-            qDebug() << "Whazzup::whazzupDownloaded() Whazzup updated from timestamp" << _data.whazzupTime;
+            qDebug() << "Whazzup updated from timestamp" << _data.whazzupTime;
             emit newData(true);
 
             if (Settings::saveWhazzupData()) {
@@ -228,11 +228,11 @@ void Whazzup::processWhazzup() {
                         .arg(_data.whazzupTime.toString("yyyyMMdd-HHmmss"))
                 ));
                 if (!out.exists() && out.open(QIODevice::WriteOnly | QIODevice::Text)) {
-                    qDebug() << "Whazzup::processWhazzup writing Whazzup to" << out.fileName();
+                    qDebug() << "Writing Whazzup to" << out.fileName();
                     out.write(bytes->constData());
                     out.close();
                 } else {
-                    qWarning() << "Whazzup::processWhazzup: Could not write Whazzup to disk" << out.fileName();
+                    qWarning() << "Could not write Whazzup to disk" << out.fileName();
                 }
             }
         } else {
@@ -250,7 +250,7 @@ void Whazzup::processWhazzup() {
             && (Settings::downloadInterval() < serverNextUpdateInSec)
         ) {
             _downloadTimer->start(serverNextUpdateInSec);
-            qDebug() << "Whazzup::whazzupDownloaded() correcting next update, will update in"
+            qDebug() << "correcting next update, will update in"
                      << serverNextUpdateInSec << "s to respect the server's minimum interval";
         } else {
             _downloadTimer->start(Settings::downloadInterval() * 1000);
@@ -287,11 +287,11 @@ void Whazzup::bookingsProgress(qint64 prog, qint64 tot) {
 }
 
 void Whazzup::processBookings() {
-    qDebug() << "Whazzup::processBookings()";
+    qDebug();
     GuiMessages::remove("bookingsDownload");
     disconnect(_replyBookings, &QNetworkReply::finished, this, &Whazzup::processBookings);
     disconnect(_replyBookings, &QNetworkReply::downloadProgress, this, &Whazzup::bookingsProgress);
-    qDebug() << "Whazzup::processBookings() deleting buffer";
+    qDebug() << "deleting buffer";
     if (_replyBookings == 0) {
         GuiMessages::criticalUserInteraction(
             "Buffer unavailable.",
@@ -317,15 +317,15 @@ void Whazzup::processBookings() {
     QByteArray* bytes = new QByteArray(_replyBookings->readAll());
     WhazzupData newBookingsData(bytes, WhazzupData::ATCBOOKINGS);
     if (!newBookingsData.isNull()) {
-        qDebug() << "Whazzup::processBookings() step 2";
+        qDebug() << "step 2";
         if (newBookingsData.bookingsTime.secsTo(QDateTime::currentDateTimeUtc()) > 60 * 60 * 3) {
             GuiMessages::warning("Bookings data more than 3 hours old.");
         }
 
         if (newBookingsData.bookingsTime != _data.bookingsTime) {
-            qDebug() << "Whazzup::processBookings() will call updateFrom()";
+            qDebug() << "will call updateFrom()";
             _data.updateFrom(newBookingsData);
-            qDebug() << "Whazzup::processBookings() Bookings updated from timestamp"
+            qDebug() << "Bookings updated from timestamp"
                      << _data.bookingsTime;
 
             QFile out(Settings::dataDirectory(
@@ -334,11 +334,11 @@ void Whazzup::processBookings() {
                     .arg(_data.bookingsTime.toString("yyyyMMdd-HHmmss"))
             ));
             if (!out.exists() && out.open(QIODevice::WriteOnly | QIODevice::Text)) {
-                qDebug() << "Whazzup::processBookings writing bookings to" << out.fileName();
+                qDebug() << "writing bookings to" << out.fileName();
                 out.write(bytes->constData());
                 out.close();
             } else {
-                qWarning() << "Whazzup::processBookings: Could not write Bookings to disk"
+                qWarning() << "Could not write Bookings to disk"
                            << out.fileName();
             }
 
@@ -353,7 +353,7 @@ void Whazzup::processBookings() {
         }
     }
     GuiMessages::remove("bookingsProcess");
-    qDebug() << "Whazzup::processBookings() -- finished";
+    qDebug() << "-- finished";
 }
 
 
@@ -373,7 +373,7 @@ QString Whazzup::metarUrl(const QString& id) const {
 
 void Whazzup::setPredictedTime(QDateTime predictedTime) {
     if (this->predictedTime != predictedTime) {
-        qDebug() << "Whazzup::setPredictedTime() predictedTime=" << predictedTime
+        qDebug() << "predictedTime=" << predictedTime
                  << "data.whazzupTime=" << _data.whazzupTime;
         GuiMessages::progress("warpProcess", "Calculating Warp...");
         this->predictedTime = predictedTime;
@@ -381,7 +381,7 @@ void Whazzup::setPredictedTime(QDateTime predictedTime) {
             emit needBookings();
         }
         if (predictedTime == _data.whazzupTime) {
-            qDebug() << "Whazzup::setPredictedTime() predictedTime == data.whazzupTime"
+            qDebug() << "predictedTime == data.whazzupTime"
                      << "(no need to predict, we have it already :) )";
             _predictedData = _data;
         } else {

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -17,7 +17,7 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type)
     : servers(QList<QStringList>()),
       updateEarliest(QDateTime()), whazzupTime(QDateTime()),
       bookingsTime(QDateTime()) {
-    qDebug() << "WhazzupData::WhazzupData(buffer)" << type << "[NONE, WHAZZUP, ATCBOOKINGS, UNIFIED]";
+    qDebug() << type << "[NONE, WHAZZUP, ATCBOOKINGS, UNIFIED]";
     _dataType = type;
     int reloadInSec = Settings::downloadInterval();
     QJsonDocument data = QJsonDocument::fromJson(*bytes);
@@ -98,7 +98,7 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type)
                 auto o = rating.toObject();
                 ratings.insert(o["id"].toInt(), o["short"].toString());
             }
-            qDebug() << "WhazzupData::WhazzupData(buffer) ratings:" << ratings;
+            qDebug() << "ratings:" << ratings;
         }
 
         if (json.contains("pilot_ratings") && json["pilot_ratings"].isArray()) {
@@ -106,7 +106,7 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type)
                 auto o = rating.toObject();
                 pilotRatings.insert(o["id"].toInt(), o["short_name"].toString());
             }
-            qDebug() << "WhazzupData::WhazzupData(buffer) pilotRatings:" << pilotRatings;
+            qDebug() << "pilotRatings:" << pilotRatings;
         }
 
         if (json.contains("military_ratings") && json["military_ratings"].isArray()) {
@@ -114,7 +114,7 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type)
                 auto o = rating.toObject();
                 militaryRatings.insert(o["id"].toInt(), o["short_name"].toString());
             }
-            qDebug() << "WhazzupData::WhazzupData(buffer) militaryRatings:" << militaryRatings;
+            qDebug() << "militaryRatings:" << militaryRatings;
         }
     } else if (type == ATCBOOKINGS) {
         QJsonArray json = data.array();
@@ -132,7 +132,7 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type)
     if (whazzupTime.isValid() && reloadInSec > 0) {
         updateEarliest = whazzupTime.addSecs(reloadInSec).toUTC();
     }
-    qDebug() << "WhazzupData::WhazzupData(buffer) -- finished";
+    qDebug() << "-- finished";
 }
 
 // faking WhazzupData based on valid data and a predictTime
@@ -141,7 +141,7 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data)
       updateEarliest(QDateTime()), whazzupTime(QDateTime()),
       bookingsTime(QDateTime()), predictionBasedOnTime(QDateTime()),
       predictionBasedOnBookingsTime(QDateTime()) {
-    qDebug() << "WhazzupData::WhazzupData(predictTime)" << predictTime;
+    qDebug() << predictTime;
 
     whazzupTime = predictTime;
     predictionBasedOnTime = QDateTime(data.whazzupTime);
@@ -182,7 +182,7 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data)
             controllers[bc->callsign] = new Controller(controllerObject, this);
         }
     }
-    qDebug() << "WhazzupData::WhazzupData(predictTime) added" << controllers.size() << "bookedControllers as fake controllers";
+    qDebug() << "added" << controllers.size() << "bookedControllers as fake controllers";
 
     // let controllers be in until he states in his Controller Info also if only found in Whazzup, not booked
     foreach (const Controller* c, data.controllers) {
@@ -282,7 +282,7 @@ WhazzupData::WhazzupData(const QDateTime predictTime, const WhazzupData &data)
 
         pilots[np->callsign] = np;
     }
-    qDebug() << "WhazzupData::WhazzupData(predictTime) -- finished";
+    qDebug() << "-- finished";
 }
 
 WhazzupData::WhazzupData(const WhazzupData &data) {
@@ -321,7 +321,7 @@ bool WhazzupData::isNull() const {
 }
 
 void WhazzupData::assignFrom(const WhazzupData &data) {
-    qDebug() << "WhazzupData::assignFrom()";
+    qDebug();
     if (this == &data) {
         return;
     }
@@ -367,11 +367,11 @@ void WhazzupData::assignFrom(const WhazzupData &data) {
         bookingsTime = QDateTime(data.bookingsTime);
         predictionBasedOnBookingsTime = QDateTime(data.predictionBasedOnBookingsTime);
     }
-    qDebug() << "WhazzupData::assignFrom() -- finished";
+    qDebug() << "-- finished";
 }
 
 void WhazzupData::updatePilotsFrom(const WhazzupData &data) {
-    qDebug() << "WhazzupData::updatePilotsFrom()";
+    qDebug();
     foreach (const QString s, pilots.keys()) { // remove pilots that are no longer there
         if (!data.pilots.contains(s)) {
             delete pilots.value(s);
@@ -409,11 +409,11 @@ void WhazzupData::updatePilotsFrom(const WhazzupData &data) {
             *bookedPilots[s] = *data.bookedPilots[s];
         }
     }
-    qDebug() << "WhazzupData::updatePilotsFrom() -- finished";
+    qDebug() << "-- finished";
 }
 
 void WhazzupData::updateControllersFrom(const WhazzupData &data) {
-    qDebug() << "WhazzupData::updateControllersFrom()";
+    qDebug();
     foreach (const QString s, controllers.keys()) {
         if (!data.controllers.contains(s)) {
             // remove controllers that are no longer there
@@ -430,20 +430,20 @@ void WhazzupData::updateControllersFrom(const WhazzupData &data) {
             *controllers[s] = *data.controllers[s];
         }
     }
-    qDebug() << "WhazzupData::updateControllersFrom() -- finished";
+    qDebug() << "-- finished";
 }
 
 void WhazzupData::updateBookedControllersFrom(const WhazzupData &data) {
-    qDebug() << "WhazzupData::updateBookedControllersFrom()" << data.bookedControllers.size() << "bookedControllers";
+    qDebug() << data.bookedControllers.size() << "bookedControllers";
     bookedControllers.clear();
     foreach (const BookedController* bc, data.bookedControllers) {
         bookedControllers.append(new BookedController(*bc));
     }
-    qDebug() << "WhazzupData::updateBookedControllersFrom() -- finished";
+    qDebug() << "-- finished";
 }
 
 void WhazzupData::updateFrom(const WhazzupData &data) {
-    qDebug() << "WhazzupData::updateFrom()";
+    qDebug();
     if (this == &data) {
         return;
     }
@@ -476,7 +476,7 @@ void WhazzupData::updateFrom(const WhazzupData &data) {
         bookingsTime = data.bookingsTime;
         predictionBasedOnBookingsTime = data.predictionBasedOnBookingsTime;
     }
-    qDebug() << "WhazzupData::updateFrom() -- finished";
+    qDebug() << "-- finished";
 }
 
 QSet<Controller*> WhazzupData::controllersWithSectors() const {
@@ -495,7 +495,6 @@ QList<Pilot*> WhazzupData::allPilots() const {
 }
 
 QList<QPair<double, double> > WhazzupData::friendsLatLon() const {
-    qDebug() << "WhazzupData::friendsLatLon()";
     QStringList friends = Settings::friends();
     QList<QPair<double, double> > result;
     foreach (Controller* c, controllers.values()) {

--- a/src/dialogs/AirportDetails.cpp
+++ b/src/dialogs/AirportDetails.cpp
@@ -229,7 +229,7 @@ void AirportDetails::togglePlotRoutes(bool checked) {
 }
 
 void AirportDetails::refreshMetar() {
-    qDebug() << "AirportDetails::refreshMetar";
+    qDebug() << _airport;
     lblMetar->setText("…");
     QList<Airport*> airports;
     if (_airport != 0) {
@@ -239,7 +239,7 @@ void AirportDetails::refreshMetar() {
 }
 
 void AirportDetails::onGotMetar(const QString &airportId, const QString &encoded, const QString &humanHtml) {
-    qDebug() << "AirportDetails::onGotMetar" << airportId << encoded;
+    qDebug() << _airport << airportId << encoded;
     if (_airport->id == airportId) {
         lblMetar->setText(encoded);
         lblMetar->setToolTip(humanHtml);

--- a/src/dialogs/ListClientsDialog.cpp
+++ b/src/dialogs/ListClientsDialog.cpp
@@ -164,7 +164,7 @@ void ListClientsDialog::performSearch() {
     _editFilterTimer.stop();
     qApp->setOverrideCursor(QCursor(Qt::WaitCursor));
 
-    qDebug() << "ListClientsDialog::performSearch()";
+    qDebug();
     QRegExp regex;
     // @todo this tries to cater for both ways (wildcards and regexp) but it does a bad job at that.
     QStringList tokens = editFilter->text()
@@ -189,7 +189,7 @@ void ListClientsDialog::performSearch() {
     // General
     boxResults->setTitle(QString("Results (%1)").arg(_clientsProxyModel->rowCount()));
     qApp->restoreOverrideCursor();
-    qDebug() << "ListClientsDialog::performSearch() -- finished";
+    qDebug() << "-- finished";
 }
 
 void ListClientsDialog::modelSelected(const QModelIndex& index) {

--- a/src/dialogs/PilotDetails.cpp
+++ b/src/dialogs/PilotDetails.cpp
@@ -227,7 +227,6 @@ void PilotDetails::on_buttonAddFriend_clicked() {
 }
 
 void PilotDetails::on_cbPlotRoute_clicked(bool checked) {
-    qDebug() << "PilotDetails::on_cbPlotRoute_clicked()" << checked;
     if (_pilot->showDepDestLine != checked) {
         _pilot->showDepDestLine = checked;
         if (Window::instance(false) != 0) {
@@ -235,7 +234,6 @@ void PilotDetails::on_cbPlotRoute_clicked(bool checked) {
         }
         refresh();
     }
-    qDebug() << "PilotDetails::on_cbPlotRoute_clicked() -- finished";
 }
 
 void PilotDetails::closeEvent(QCloseEvent* event) {

--- a/src/dialogs/PlanFlightDialog.cpp
+++ b/src/dialogs/PlanFlightDialog.cpp
@@ -141,7 +141,6 @@ void PlanFlightDialog::requestVroute() {
 }
 
 void PlanFlightDialog::vrouteDownloaded() {
-    qDebug() << "PlanFlightDialog::vrouteDownloaded()";
     disconnect(_replyVroute, &QNetworkReply::finished, this, &PlanFlightDialog::vrouteDownloaded);
     _replyVroute->deleteLater();
 
@@ -322,13 +321,11 @@ void PlanFlightDialog::plotPlannedRoute() const {
 }
 
 void PlanFlightDialog::on_cbPlot_toggled(bool checked) {
-    qDebug() << "PlanFlightDialog::on_cbPlot_toggled()" << checked;
     if (Window::instance(false) != 0) {
         Window::instance()->mapScreen->glWidget->invalidatePilots();
     }
     lblPlotStatus->setVisible(checked);
     linePlotStatus->setVisible(checked);
-    qDebug() << "PlanFlightDialog::on_cbPlot_toggled() -- finished";
 }
 
 void PlanFlightDialog::on_pbCopyToClipboard_clicked() {

--- a/src/dialogs/StaticSectorsDialog.cpp
+++ b/src/dialogs/StaticSectorsDialog.cpp
@@ -41,7 +41,7 @@ StaticSectorsDialog::StaticSectorsDialog(QWidget* parent)
 }
 
 void StaticSectorsDialog::loadSectorList() {
-    qDebug() << "StaticSectorsDialog::loadSectorList -- started";
+    qDebug();
     foreach (const auto sector, NavData::instance()->sectors.values()) {
         QListWidgetItem* item = new QListWidgetItem();
         item->setText(
@@ -86,7 +86,7 @@ void StaticSectorsDialog::loadSectorList() {
         listWidgetSectors->addItem(item);
     }
     listWidgetSectors->sortItems();
-    qDebug() << "StaticSectorsDialog::loadSectorList -- finsished";
+    qDebug() << "-- finsished";
 }
 
 void StaticSectorsDialog::closeEvent(QCloseEvent* event) {

--- a/src/dialogs/Window.cpp
+++ b/src/dialogs/Window.cpp
@@ -50,7 +50,7 @@ Window::Window(QWidget* parent)
 
     // apply styleSheet
     if (!Settings::stylesheet().isEmpty()) {
-        qDebug() << "Window::() applying styleSheet:" << Settings::stylesheet();
+        qDebug() << "applying styleSheet:" << Settings::stylesheet();
         setStyleSheet(Settings::stylesheet());
     }
 
@@ -189,13 +189,13 @@ Window::Window(QWidget* parent)
     GuiMessages::instance()->addStatusLabel(_lblStatus, false);
 
     GuiMessages::remove("mainwindow");
-    qDebug() << "Window::() --finished";
+    qDebug() << "--finished";
 }
 
 Window::~Window() {}
 
 void Window::restore() {
-    qDebug() << "Window::restore() restoring window state, geometry and position";
+    qDebug() << "restoring window state, geometry and position";
 
     if (!Settings::savedSize().isNull()) {
         resize(Settings::savedSize());
@@ -263,7 +263,7 @@ void Window::about() {
 }
 
 void Window::processWhazzup(bool isNew) {
-    qDebug() << "Window::whazzupDownloaded() isNew =" << isNew;
+    qDebug() << "isNew =" << isNew;
     const WhazzupData &realdata = Whazzup::instance()->realWhazzupData();
     const WhazzupData &data = Whazzup::instance()->whazzupData();
 
@@ -364,7 +364,7 @@ void Window::processWhazzup(bool isNew) {
         _timerWatchdog.start(Settings::downloadInterval() * 1000 * 4);
     }
 
-    qDebug() << "Window::whazzupDownloaded() -- finished";
+    qDebug() << "-- finished";
 }
 
 void Window::refreshFriends() {
@@ -574,9 +574,9 @@ void Window::performWarp() {
 
     QDateTime warpToTime = dateTimePredict->dateTime();
     auto realWhazzupTime = Whazzup::instance()->realWhazzupData().whazzupTime;
-    qDebug() << "Window::performWarp() warpToTime=" << warpToTime << " realWhazzupTime=" << realWhazzupTime;
+    qDebug() << "warpToTime=" << warpToTime << " realWhazzupTime=" << realWhazzupTime;
     if (cbUseDownloaded->isChecked() && warpToTime < realWhazzupTime) {
-        qDebug() << "Window::performWarp() Looking for downloaded Whazzups";
+        qDebug() << "Looking for downloaded Whazzups";
         QList<QPair<QDateTime, QString> > downloaded = Whazzup::instance()->downloadedWhazzups();
         for (int i = downloaded.size() - 1; i > -1; i--) {
             if ((downloaded[i].first <= warpToTime && realWhazzupTime < downloaded[i].first) || (i == 0)) {
@@ -599,7 +599,7 @@ void Window::performWarp() {
 }
 
 void Window::on_cbUseDownloaded_toggled(bool checked) {
-    qDebug() << "Window::cbUseDownloaded_toggled()" << checked;
+    qDebug() << "checked=" << checked;
     if (!checked) {
         // I currently don't understand why we had this
         //        QList<QPair<QDateTime, QString> > downloaded = Whazzup::instance()->downloadedWhazzups();
@@ -616,8 +616,7 @@ void Window::on_cbOnlyUseDownloaded_toggled(bool checked) {
 }
 
 void Window::on_tbDisablePredict_clicked() {
-    qDebug() << "Window::tbDisablePredict_clicked()";
-    //this->on_actionPredict_toggled(false); // we do this by toggling the menu item
+    qDebug();
     actionPredict->setChecked(false);
 }
 
@@ -663,7 +662,7 @@ void Window::runPredict() {
 
     // when only using downloaded Whazzups, select the next available
     if (cbOnlyUseDownloaded->isChecked()) {
-        qDebug() << "Window::runPredict() restricting Warp target to downloaded Whazzups";
+        qDebug() << "restricting Warp target to downloaded Whazzups";
         QList<QPair<QDateTime, QString> > downloaded = Whazzup::instance()->downloadedWhazzups();
         for (int i = 0; i < downloaded.size(); i++) {
             if ((downloaded[i].first >= to) || (i == downloaded.size() - 1)) {
@@ -755,8 +754,7 @@ void Window::dateTimePredict_dateTimeChanged(QDateTime dateTime) {
 
     // when only using downloaded Whazzups, select the next available
     if (cbOnlyUseDownloaded->isChecked()) {
-        qDebug() << "Window::dateTimePredict_dateTimeChanged()"
-                 << "restricting Warp target to downloaded Whazzups";
+        qDebug() << "restricting Warp target to downloaded Whazzups";
         QList<QPair<QDateTime, QString> > downloaded =
             Whazzup::instance()->downloadedWhazzups();
         if (dateTime > _dateTimePredict_old) { // selecting a later date
@@ -904,7 +902,6 @@ void Window::on_actionZoomReset_triggered() {
 }
 
 void Window::actionShowRoutes_triggered(bool checked, bool showStatus) {
-    qDebug() << "Window::on_actionShowRoutes_triggered()" << checked;
     Settings::setShowRoutes(checked);
     if (showStatus) {
         GuiMessages::message(QString("toggled routes [%1]").arg(checked? "on": "off"), "routeToggle");
@@ -927,18 +924,15 @@ void Window::actionShowRoutes_triggered(bool checked, bool showStatus) {
     }
 
     mapScreen->glWidget->invalidatePilots();
-    qDebug() << "Window::on_actionShowRoutes_triggered() -- finished";
 }
 
 void Window::actionShowImmediateRoutes_triggered(bool checked, bool showStatus) {
-    qDebug() << "Window::on_actionShowImmediateRoutes_triggered()" << checked;
     Settings::setOnlyShowImmediateRoutePart(checked);
     if (showStatus) {
         GuiMessages::message(QString("toggled short-term routes [%1]").arg(checked? "on": "off"), "routeToggle");
     }
 
     mapScreen->glWidget->invalidatePilots();
-    qDebug() << "Window::on_actionShowImmediateRoutes_triggered() -- finished";
 }
 
 void Window::showInactiveAirports(bool checked) {

--- a/src/models/ListClientsDialogModel.cpp
+++ b/src/models/ListClientsDialogModel.cpp
@@ -4,11 +4,11 @@
 #include "../NavData.h"
 
 void ListClientsDialogModel::setClients(const QList<Client*>& clients) {
-    qDebug() << "ListClientsDialogModel::setClients()";
+    qDebug();
     beginResetModel();
     _clients = clients;
     endResetModel();
-    qDebug() << "ListClientsDialogModel::setClients() -- finished";
+    qDebug() << "-- finished";
 }
 
 QVariant ListClientsDialogModel::headerData(int section, enum Qt::Orientation orientation, int role) const {

--- a/src/models/MetarModel.cpp
+++ b/src/models/MetarModel.cpp
@@ -130,7 +130,7 @@ void MetarModel::downloadMetarFor(Airport* airport) {
 
     QUrl url(location);
 
-    qDebug() << "MetarModel::downloadMetarFor()" << airport->id << url;
+    qDebug() << airport->id << url;
 
     _downloadQueue.insert(url, airport);
     downloadNextFromQueue();
@@ -138,14 +138,14 @@ void MetarModel::downloadMetarFor(Airport* airport) {
 }
 
 void MetarModel::downloadNextFromQueue() {
-    qDebug() << "MetarModel::downloadNextFromQueue() queue.count=" << _downloadQueue.count();
+    qDebug() << "queue.count=" << _downloadQueue.count();
 
     if (_downloadQueue.isEmpty()) {
         return;
     }
 
     if (_metarReply != 0 && !_metarReply->isFinished()) {
-        qDebug() << "MetarModel::downloadNextFromQueue() _metarReply still running";
+        qDebug() << "_metarReply still running";
         return; // we will be called via downloaded() later
     }
 
@@ -154,7 +154,7 @@ void MetarModel::downloadNextFromQueue() {
 }
 
 void MetarModel::metarReplyFinished() {
-    qDebug() << "MetarModel::downloaded()" << _metarReply->url();
+    qDebug() << _metarReply->url();
     disconnect(_metarReply, &QNetworkReply::finished, this, &MetarModel::metarReplyFinished);
 
     if (_metarReply->error() == QNetworkReply::NoError) {
@@ -181,7 +181,7 @@ void MetarModel::gotMetarFor(Airport* airport) {
         if (!_metarList.contains(airport)) {
             _metarList.append(airport);
         }
-        qDebug() << "MetarModel::gotMetarFor()" << airport->id << ":" << airport->metar.encoded;
+        qDebug() << airport->id << ":" << airport->metar.encoded;
         emit gotMetar(airport->id, airport->metar.encoded, airport->metar.humanHtml());
         endResetModel();
     }


### PR DESCRIPTION
It was a bit cumbersome to quickly print Qt container types to stdout. Now we can just use qCritical() << ... . It ends up in the log and on stdout.

Also qDebug() and friends bring in file, line number and function signature now (and that is enabled for release builds, too). In places where we want to customize that we use QMessageLogger (see Airac.cpp for example).