### PR TITLE
[BUGFIX] remove friend display from secondary airports

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -221,7 +221,7 @@ bool Controller::isAtis() const {
     return callsign.endsWith("_ATIS");
 }
 
-QSet <Airport*> Controller::airports() const {
+QSet <Airport*> Controller::airports(bool withAdditionalMatches) const {
     auto airports = QSet<Airport*>();
     auto _atcLabelTokens = atcLabelTokens();
     if (_atcLabelTokens.empty()) {
@@ -235,11 +235,13 @@ QSet <Airport*> Controller::airports() const {
         airports.insert(a);
     }
 
-    auto suffix = _atcLabelTokens.constLast();
-    // use matches from controllerAirportsMapping.dat
-    auto _airports = NavData::instance()->additionalMatchedAirportsForController(prefix, suffix);
-    foreach (const auto& _a, _airports) {
-        airports.insert(_a);
+    if (withAdditionalMatches) {
+        auto suffix = _atcLabelTokens.constLast();
+        // use matches from controllerAirportsMapping.dat
+        auto _airports = NavData::instance()->additionalMatchedAirportsForController(prefix, suffix);
+        foreach (const auto& _a, _airports) {
+            airports.insert(_a);
+        }
     }
 
 //    if(sector != 0) {

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -51,7 +51,7 @@ class Controller
         bool isDel() const;
         bool isAtis() const;
 
-        QSet<Airport*> airports() const;
+        QSet<Airport*> airports(bool withAdditionalMatches = true) const;
         QList<Airport*> airportsSorted() const;
 
         const QString cpdlcString() const;

--- a/src/GLWidget.cpp
+++ b/src/GLWidget.cpp
@@ -1894,6 +1894,7 @@ void GLWidget::renderLabels(
         // pilots, controllers
         Client* cl = dynamic_cast <Client*> (o);
         if (cl != 0) {
+            // Pilots and Controllers
             isFriend = cl->isFriend();
         } else {
             // airports (having a controller that is in the friends list)
@@ -1901,8 +1902,11 @@ void GLWidget::renderLabels(
             if (a != 0) {
                 foreach (const auto c, a->allControllers()) {
                     if (c->isFriend()) {
-                        isFriend = true;
-                        break;
+                        // only if that is the primary airport
+                        if (c->airports(false).contains(a)) {
+                            isFriend = true;
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This only shows the special label rectangle for friends on primary airports for controllers, not the additionally added ones through data/controllerAirportsMapping.dat.