### PR TITLE
[TASK] remove "hourglass cursor" while searching

### DIFF
--- a/src/dialogs/Window.cpp
+++ b/src/dialogs/Window.cpp
@@ -424,16 +424,19 @@ void Window::performSearch() {
     }
     _timerSearch.stop();
 
-    qApp->setOverrideCursor(QCursor(Qt::WaitCursor));
+    _modelSearchResult.m_isSearching = true;
+    searchResult->reset();
+    searchResult->repaint();
+    qApp->processEvents();
+
     SearchVisitor* visitor = new SearchVisitor(searchEdit->text());
     NavData::instance()->accept(visitor);
     Whazzup::instance()->whazzupData().accept(visitor);
-
     _modelSearchResult.setSearchResults(visitor->result());
     delete visitor;
 
+    _modelSearchResult.m_isSearching = false;
     searchResult->reset();
-    qApp->restoreOverrideCursor();
 }
 
 void Window::closeEvent(QCloseEvent* event) {

--- a/src/models/SearchResultModel.cpp
+++ b/src/models/SearchResultModel.cpp
@@ -68,8 +68,12 @@ QVariant SearchResultModel::headerData(int section, enum Qt::Orientation orienta
         return QVariant();
     }
 
+    if (m_isSearching) {
+        return "…";
+    }
+
     if (_content.isEmpty()) {
-        return QString("No Results");
+        return "No Results";
     }
 
     return QString("%1 Result%2").arg(_content.size()).arg(_content.size() == 1? "": "s");

--- a/src/models/SearchResultModel.h
+++ b/src/models/SearchResultModel.h
@@ -19,6 +19,8 @@ class SearchResultModel
             Qt::Orientation orientation,
             int role = Qt::DisplayRole
         ) const override;
+
+        bool m_isSearching = false;
     public slots:
         void setSearchResults(const QList<MapObject*>& searchResult);
         void modelClicked(const QModelIndex& index);


### PR DESCRIPTION
Since new Whazzup data triggers a new search, this became unpleasant when doing time warps. It now shows … while searching.