### PR TITLE
[FEATURE] regognize VOR/DMEs

### DIFF
--- a/src/Airac.cpp
+++ b/src/Airac.cpp
@@ -137,12 +137,20 @@ void Airac::readNavaids(const QString& directory) {
             continue;
         }
 
-        // we ignore all the rest (for now)
+        // we only add those useful to us (for now)
         if (
             nav->type() == NavAid::Type::NDB || nav->type() == NavAid::Type::VOR
             || nav->type() == NavAid::Type::DME // yes, some airways actually use that
         ) {
             navaids[nav->id].insert(nav);
+        } else if (nav->type() == NavAid::Type::DME_NO_FREQ) {
+            // upgrade VOR to VOR/DME - this assumes the DME_NO_FREQ line is always after the main VOR
+            foreach (auto* _n, navaids.value(nav->id)) {
+                if (_n->regionCode != nav->regionCode) {
+                    continue;
+                }
+                _n->upgradeToVorDme();
+            }
         }
     }
     qDebug() << "Read navaids from" << (directory + "/earth_nav.dat")

--- a/src/NavAid.cpp
+++ b/src/NavAid.cpp
@@ -1,5 +1,22 @@
 #include "NavAid.h"
 
+const QHash<NavAid::Type, QString> NavAid::typeStrings = {
+    { NDB, "NDB" },
+    { VOR, "VOR" },
+    { ILS_LOC, "ILS" },
+    { LOC, "LOC" },
+    { GS, "GS" },
+    { OM, "OM" },
+    { MM, "OM" },
+    { IM, "IM" },
+    { DME_NO_FREQ, "DME (no freq)" },
+    { DME, "DME" },
+    { FAP_GBAS, "FAP alignment point" },
+    { GBAS_GND, "GBAS Ground station" },
+    { GBAS_THR, "GBAS Threshold point" },
+    { CUSTOM_VORDME, "VOR/DME" }
+};
+
 NavAid::NavAid(const QStringList&stringList) {
     if (stringList.size() < 12) {
         QMessageLogger("earth_nav.dat", 0, QT_MESSAGELOG_FUNC).critical()
@@ -47,23 +64,7 @@ NavAid::NavAid(const QStringList&stringList) {
 }
 
 QString NavAid::typeStr(Type type) {
-    QHash<Type, QString> hash;
-    hash.reserve(10);
-    hash.insert(NDB, "NDB");
-    hash.insert(VOR, "VOR");
-    hash.insert(DME, "DME");
-    hash.insert(ILS_LOC, "ILS");
-    hash.insert(LOC, "LOC");
-    hash.insert(GS, "GS");
-    hash.insert(OM, "OM");
-    hash.insert(MM, "OM");
-    hash.insert(IM, "IM");
-    hash.insert(DME_NO_FREQ, "DME (no freq)");
-    hash.insert(DME, "DME");
-    hash.insert(FAP_GBAS, "FAP alignment point");
-    hash.insert(GBAS_GND, "GBAS Ground station");
-    hash.insert(GBAS_THR, "GBAS Threshold point");
-    return hash.value(type, QString());
+    return typeStrings.value(type, QString());
 }
 
 QString NavAid::toolTip() const {
@@ -71,7 +72,11 @@ QString NavAid::toolTip() const {
 
     if (_type == NDB) {
         ret.append(QString(" %1 kHz").arg(_freq));
-    } else if (_type == VOR || _type == DME || _type == DME_NO_FREQ || _type == ILS_LOC || _type == LOC || _type == GS) {
+    } else if (
+        _type == VOR || _type == DME || _type == DME_NO_FREQ
+        || _type == ILS_LOC || _type == LOC || _type == GS
+        || _type == CUSTOM_VORDME
+    ) {
         ret.append(QString(" %1 MHz").arg(_freq / 100., 0, 'f', 2));
     } else if (_freq != 0) {
         ret.append(QString(" %1?").arg(_freq));
@@ -96,7 +101,11 @@ QStringList NavAid::mapLabelSecondaryLinesHovered() const {
 QString NavAid::freqString() const {
     if (_type == NDB) {
         return QString("%1 kHz").arg(_freq);
-    } else if (_type == VOR || _type == DME || _type == DME_NO_FREQ || _type == ILS_LOC || _type == LOC || _type == GS) {
+    } else if (
+        _type == VOR || _type == DME || _type == DME_NO_FREQ
+        || _type == ILS_LOC || _type == LOC || _type == GS
+        || _type == CUSTOM_VORDME
+    ) {
         return QString("%1 MHz").arg(_freq / 100., 0, 'f', 2);
     }
 
@@ -105,4 +114,10 @@ QString NavAid::freqString() const {
 
 int NavAid::type() {
     return _type;
+}
+
+void NavAid::upgradeToVorDme() {
+    if (_type == VOR) {
+        _type = CUSTOM_VORDME;
+    }
 }

--- a/src/NavAid.h
+++ b/src/NavAid.h
@@ -19,9 +19,11 @@ class NavAid
             DME = 13,
             FAP_GBAS = 14,
             GBAS_GND = 15,
-            GBAS_THR = 16
+            GBAS_THR = 16,
+            CUSTOM_VORDME = 99,
         };
         static QString typeStr(Type _type);
+        static const QHash<Type, QString> typeStrings;
 
         NavAid(const QStringList& stringList);
 
@@ -29,6 +31,8 @@ class NavAid
         virtual QString mapLabelHovered() const override;
         virtual QStringList mapLabelSecondaryLinesHovered() const override;
         virtual int type() override;
+
+        void upgradeToVorDme();
 
         QString freqString() const;
     private:


### PR DESCRIPTION
The X-Plane Navdata has VOR and its DME component in different objects. This change merges this information to be able to correctly output "VOR/DME" in navaid map labels on hover.