### PR TITLE
[FEATURE] Rework routes logic (again)

### DIFF
--- a/src/Airport.cpp
+++ b/src/Airport.cpp
@@ -108,8 +108,6 @@ Airport::Airport(const QStringList& list, unsigned int debugLineNumber)
 
     lat = list[4].toDouble();
     lon = list[5].toDouble();
-
-    showRoutes = Settings::showRoutes();
 }
 
 Airport::~Airport() {

--- a/src/Airport.h
+++ b/src/Airport.h
@@ -79,7 +79,7 @@ class Airport
 
         Metar metar;
         QString id, name, city, countryCode;
-        bool showRoutes;
+        bool showRoutes = false;
         bool active;
     private:
         GLuint _appDisplayList, _twrDisplayList, _gndDisplayList, _delDisplayList;

--- a/src/Pilot.cpp
+++ b/src/Pilot.cpp
@@ -175,7 +175,6 @@ Pilot::Pilot(const QJsonObject& json, const WhazzupData* whazzup)
         dayOfFlight = whazzupTime.date().addDays(-1); // started the day before
 
     }
-    showDepDestLine = Settings::showRoutes();
 
     checkStatus();
 }
@@ -675,38 +674,6 @@ int Pilot::nextPointOnRoute(const QList<Waypoint*> &waypoints) const { // next p
         }
     }
     return qMin(nextPoint, waypoints.size());
-}
-
-bool Pilot::showDepLine() const {
-    if (qFuzzyIsNull(Settings::depLineStrength())) {
-        return false;
-    }
-
-    if (showDepDestLine) {
-        return true;
-    }
-
-    if (depAirport() != 0) {
-        return depAirport()->showRoutes;
-    }
-
-    return false;
-}
-
-bool Pilot::showDestLine() const {
-    if (qFuzzyIsNull(Settings::destLineStrength()) && qFuzzyIsNull(Settings::destImmediateLineStrength())) {
-        return false;
-    }
-
-    if (showDepDestLine) {
-        return true;
-    }
-
-    if (destAirport() != 0) {
-        return destAirport()->showRoutes;
-    }
-
-    return false;
 }
 
 QString Pilot::livestreamString(bool shortened) const {

--- a/src/Pilot.h
+++ b/src/Pilot.h
@@ -61,8 +61,6 @@ class Pilot
         QString flOrEmpty() const; // altitude prefixed with F
         QPair<double, double> positionInFuture(int seconds) const;
         int nextPointOnRoute(const QList<Waypoint*> &waypoints) const;
-        bool showDepLine() const,
-        showDestLine() const;
         QString routeWaypointsString();
         QList<Waypoint*> routeWaypoints();
         QList<Waypoint*> routeWaypointsWithDepDest();
@@ -80,7 +78,7 @@ class Pilot
             qnh_mb;
         int pilotRating = -99, militaryRating = -99;
         double trueHeading, qnh_inHg;
-        bool showDepDestLine;
+        bool showRoute = false;
         QDateTime whazzupTime; // need some local reference to that
         QList<Waypoint*> routeWaypointsCache; // caching calculated routeWaypoints
         Airline* airline;

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -384,7 +384,7 @@ void WhazzupData::updatePilotsFrom(const WhazzupData &data) {
             Pilot* p = new Pilot(*data.pilots[s]);
             pilots[s] = p;
         } else { // existing pilots: data saved in the object needs to be transferred
-            data.pilots[s]->showDepDestLine = pilots[s]->showDepDestLine;
+            data.pilots[s]->showRoute = pilots[s]->showRoute;
             data.pilots[s]->routeWaypointsCache = pilots[s]->routeWaypointsCache;
             data.pilots[s]->routeWaypointsPlanDepCache = pilots[s]->routeWaypointsPlanDepCache;
             data.pilots[s]->routeWaypointsPlanDestCache = pilots[s]->routeWaypointsPlanDestCache;

--- a/src/dialogs/AirportDetails.cpp
+++ b/src/dialogs/AirportDetails.cpp
@@ -218,7 +218,17 @@ void AirportDetails::refresh(Airport* newAirport) {
     groupBoxAtc->setTitle(QString("ATC (%1)").arg(atcContent.size()));
     treeAtc->header()->resizeSections(QHeaderView::ResizeToContents);
 
-    cbPlotRoutes->setChecked(_airport->showRoutes);
+    bool isShowRouteExternal = Settings::showRoutes();
+
+    if (!isShowRouteExternal && !_airport->showRoutes) {
+        cbPlotRoutes->setCheckState(Qt::Unchecked);
+    }
+    if (isShowRouteExternal && !_airport->showRoutes) {
+        cbPlotRoutes->setCheckState(Qt::PartiallyChecked);
+    }
+    if (_airport->showRoutes) {
+        cbPlotRoutes->setCheckState(Qt::Checked);
+    }
 }
 
 void AirportDetails::atcSelected(const QModelIndex& index) {
@@ -234,15 +244,14 @@ void AirportDetails::departureSelected(const QModelIndex& index) {
 }
 
 void AirportDetails::togglePlotRoutes(bool checked) {
-    if (_airport->showRoutes != checked) {
-        _airport->showRoutes = checked;
-        if (Window::instance(false) != 0) {
-            Window::instance()->mapScreen->glWidget->invalidatePilots();
-        }
-        if (PilotDetails::instance(false) != 0) {
-            PilotDetails::instance()->refresh();
-        }
+    _airport->showRoutes = checked;
+    if (Window::instance(false) != 0) {
+        Window::instance()->mapScreen->glWidget->invalidatePilots();
     }
+    if (PilotDetails::instance(false) != 0) {
+        PilotDetails::instance()->refresh();
+    }
+    refresh();
 }
 
 void AirportDetails::refreshMetar() {

--- a/src/dialogs/PreferencesDialog.ui
+++ b/src/dialogs/PreferencesDialog.ui
@@ -1510,10 +1510,22 @@ TWR: 133.375</string>
               <x>0</x>
               <y>0</y>
               <width>469</width>
-              <height>733</height>
+              <height>715</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_2">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <item>
               <widget class="QGroupBox" name="groupBox_11">
                <property name="title">

--- a/src/dialogs/Window.cpp
+++ b/src/dialogs/Window.cpp
@@ -909,21 +909,24 @@ void Window::actionShowRoutes_triggered(bool checked, bool showStatus) {
     if (showStatus) {
         GuiMessages::message(QString("toggled routes [%1]").arg(checked? "on": "off"), "routeToggle");
     }
-    foreach (Airport* a, NavData::instance()->airports.values()) { // synonym to "toggle routes" on all airports
-        a->showRoutes = checked;
-    }
-    if (!checked) { // when disabled, this shall clear all routes
-        foreach (Pilot* p, Whazzup::instance()->whazzupData().allPilots()) {
-            p->showDepDestLine = false;
-        }
-    }
 
-    // adjust the "plot route" tick in dialogs
-    if (AirportDetails::instance(false) != 0) {
-        AirportDetails::instance()->refresh();
-    }
-    if (PilotDetails::instance(false) != 0) {
-        PilotDetails::instance()->refresh();
+    actionShowImmediateRoutes->setEnabled(checked);
+
+    if (!checked) {
+        foreach (Airport* a, NavData::instance()->airports.values()) {
+            a->showRoutes = checked;
+        }
+        foreach (Pilot* p, Whazzup::instance()->whazzupData().allPilots()) {
+            p->showRoute = checked;
+        }
+
+        // adjust the "plot route" tick in dialogs
+        if (AirportDetails::instance(false) != 0) {
+            AirportDetails::instance()->refresh();
+        }
+        if (PilotDetails::instance(false) != 0) {
+            PilotDetails::instance()->refresh();
+        }
     }
 
     mapScreen->glWidget->invalidatePilots();


### PR DESCRIPTION
Only "Display all routes" respects the "Only show short-term route parts"
setting.

Full routes are alays shows when an airport/pilot is right-clicked or
"plot route" is selected from the detail dialog.