### PR TITLE
[FEATURE] Introduce template language for labels

### DIFF
--- a/QuteScoop.pro
+++ b/QuteScoop.pro
@@ -201,7 +201,12 @@ HEADERS += \
     src/Net.h \
     src/JobList.h \
     src/MetarDelegate.h \
-    src/Platform.h
+    src/Platform.h \
+    src/mustache/Renderer.h \
+    src/mustache/contexts/AirportContext.h \
+    src/mustache/contexts/ControllerContext.h \
+    src/mustache/contexts/PilotContext.h \
+    src/mustache/external/qt-mustache/mustache.h
 SOURCES += src/WhazzupData.cpp \
     src/Whazzup.cpp \
     src/Waypoint.cpp \
@@ -257,7 +262,12 @@ SOURCES += src/WhazzupData.cpp \
     src/Net.cpp \
     src/JobList.cpp \
     src/MetarDelegate.cpp \
-    src/Platform.cpp
+    src/Platform.cpp \
+    src/mustache/Renderer.cpp \
+    src/mustache/contexts/AirportContext.cpp \
+    src/mustache/contexts/ControllerContext.cpp \
+    src/mustache/contexts/PilotContext.cpp \
+    src/mustache/external/qt-mustache/mustache.cpp
 RESOURCES += src/Resources.qrc
 
 # Report DESTDIR to user

--- a/bin/uncrustify-check.sh
+++ b/bin/uncrustify-check.sh
@@ -4,5 +4,5 @@
 #
 # @see .github/workflows/build.yaml for used crustify version
 
-uncrustify -q -c uncrustify.cfg --check src/*.{h,cpp} src/*/*.{h,cpp} \
+uncrustify -q -c uncrustify.cfg --check src/*.{h,cpp} src/*/*.{h,cpp} src/*/*/*.{h,cpp} \
 	|| ( echo "There were linting issues."; false )

--- a/bin/uncrustify-fix.sh
+++ b/bin/uncrustify-fix.sh
@@ -3,4 +3,4 @@
 #
 # @see .github/workflows/build.yaml for used crustify version
 
-uncrustify -q -c uncrustify.cfg --replace --no-backup src/*.{h,cpp} src/*/*.{h,cpp}
+uncrustify -q -c uncrustify.cfg --replace --no-backup src/*.{h,cpp} src/*/*.{h,cpp} src/*/*/*.{h,cpp}

--- a/src/Airport.h
+++ b/src/Airport.h
@@ -5,20 +5,7 @@
 #include "MapObject.h"
 #include "Metar.h"
 #include "Pilot.h"
-
-// that was to use the QJSEngine for the labels. But basically it was way too slow for us.
-//class AirportApi: public QObject {
-//    Q_OBJECT
-//    public:
-//        AirportApi(Airport* _a);
-//        virtual ~AirportApi();
-//        Q_PROPERTY(QString traffic READ _traffic CONSTANT);
-//        Q_PROPERTY(QString controllers READ _controllers CONSTANT);
-//    private:
-//        QString _traffic();
-//        QString _controllers();
-//        Airport* m_airport;
-//};
+#include "src/mustache/contexts/AirportContext.h"
 
 class Airport
     : public MapObject {
@@ -28,7 +15,6 @@ class Airport
         const static int symbologyTwrRadius_nm = 16;
         const static int symbologyGndRadius_nm = 13;
         const static int symbologyDelRadius_nm = 10;
-        static const QHash<QString, std::function<QString(Airport*)> > placeholders;
         static const QRegularExpression pdcRegExp;
 
         Airport(const QStringList &list, unsigned int debugLineNumber = 0);
@@ -45,14 +31,11 @@ class Airport
 
         void showDetailsDialog();
 
-        QString livestreamString(bool shortened = false) const;
+        QString livestreamString() const;
 
         const QString shortLabel() const;
-        const QString longLabel() const;
         const QString prettyName() const;
         const QString trafficString() const;
-        const QString trafficFilteredString() const;
-        const QString trafficUnfilteredString() const;
         const QString controllersString() const;
         const QString atisCodeString() const;
         const QString frequencyString() const;
@@ -72,19 +55,20 @@ class Airport
 
         void addController(Controller* c);
 
-        const GLuint &appDisplayList();
-        const GLuint &twrDisplayList();
-        const GLuint &gndDisplayList();
-        const GLuint &delDisplayList();
+        const GLuint& appDisplayList();
+        const GLuint& twrDisplayList();
+        const GLuint& gndDisplayList();
+        const GLuint& delDisplayList();
 
         Metar metar;
         QString id, name, city, countryCode;
         bool showRoutes = false;
         bool active;
     private:
-        GLuint _appDisplayList, _twrDisplayList, _gndDisplayList, _delDisplayList;
         void appGl(const QColor &middleColor, const QColor &marginColor, const QColor &borderColor, const GLfloat &borderLineWidth) const;
         void twrGl(const QColor &middleColor, const QColor &marginColor, const QColor &borderColor, const GLfloat &borderLineWidth) const;
+
+        GLuint _appDisplayList, _twrDisplayList, _gndDisplayList, _delDisplayList;
 };
 
-#endif /*AIRPORT_H_*/
+#endif

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -15,7 +15,7 @@ const QRegularExpression Client::livestreamRegExp = QRegularExpression(
     QRegularExpression::MultilineOption | QRegularExpression::CaseInsensitiveOption
 );
 
-QString Client::livestreamString(const QString& str, bool shortened) {
+QString Client::livestreamString(const QString& str) {
     auto matchIterator = livestreamRegExp.globalMatch(str);
 
     // take last match. Helps with "live on twitch now: twitch/user"
@@ -23,9 +23,6 @@ QString Client::livestreamString(const QString& str, bool shortened) {
         auto match = matchIterator.next();
         if (!matchIterator.hasNext()) {
             QString network(match.captured(2) + match.captured(4) + match.captured(6));
-            if (shortened) {
-                return "~";
-            }
             return network.toLower() + "/" + match.capturedRef(8);
         }
     }
@@ -34,7 +31,7 @@ QString Client::livestreamString(const QString& str, bool shortened) {
 }
 
 Client::Client(const QJsonObject& json, const WhazzupData*)
-    : server("") {
+    : callsign(""), userId(""), homeBase(""), server(""), rating(-99) {
     callsign = json["callsign"].toString();
     Q_ASSERT(!callsign.isNull());
 
@@ -116,7 +113,7 @@ QString Client::rank() const {
     return "";
 }
 
-QString Client::livestreamString(bool) const {
+QString Client::livestreamString() const {
     return "";
 }
 

--- a/src/Client.h
+++ b/src/Client.h
@@ -8,13 +8,13 @@
 class Client {
     public:
         static const QRegularExpression livestreamRegExp;
-        static QString livestreamString(const QString& str, bool shortened = false);
+        static QString livestreamString(const QString& str);
 
         Client(const QJsonObject& json, const WhazzupData* whazzup);
 
         virtual bool matches(const QRegExp& regex) const;
         virtual QString rank() const;
-        virtual QString livestreamString(bool shortened = false) const;
+        virtual QString livestreamString() const;
         virtual bool isFriend() const;
         virtual const QString realName() const;
         virtual const QString nameOrCid() const;
@@ -30,7 +30,7 @@ class Client {
 
         bool showAliasDialog(QWidget* parent) const;
 
-        int rating = -99;
+        int rating;
 
         static bool isValidID(const QString id);
         bool hasValidID() const;

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -5,6 +5,7 @@
 #include "MapObject.h"
 #include "Sector.h"
 #include "WhazzupData.h"
+#include "src/mustache/contexts/ControllerContext.h"
 
 #include <QJsonObject>
 
@@ -14,7 +15,6 @@ class Controller
     : public MapObject, public Client {
     Q_OBJECT
     public:
-        static const QHash<QString, std::function<QString(Controller*)> > placeholders;
         static const QRegularExpression cpdlcRegExp;
 
         Controller(const QJsonObject& json, const WhazzupData* whazzup);
@@ -27,7 +27,7 @@ class Controller
         virtual QString mapLabelHovered() const override;
         virtual QStringList mapLabelSecondaryLines() const override;
         virtual QStringList mapLabelSecondaryLinesHovered() const override;
-        virtual QString livestreamString(bool shortened = false) const override;
+        virtual QString livestreamString() const override;
         virtual bool matches(const QRegExp& regex) const override;
         virtual bool hasPrimaryAction() const override;
         virtual void primaryAction() override;
@@ -62,9 +62,6 @@ class Controller
         QDateTime assumeOnlineUntil;
 
         Sector* sector;
-    protected:
-        QString specialAirportWorkarounds(const QString& rawAirport) const;
-    private:
 };
 
 #endif /*CONTROLLER_H_*/

--- a/src/Pilot.h
+++ b/src/Pilot.h
@@ -5,6 +5,7 @@
 #include "Client.h"
 #include "MapObject.h"
 #include "Waypoint.h"
+#include "src/mustache/contexts/PilotContext.h"
 
 #include <QJsonDocument>
 
@@ -16,7 +17,6 @@ class Pilot
     public:
         static const int taxiTimeOutbound = 240;
         static int altToFl(int alt_ft, int qnh_mb);
-        static const QHash<QString, std::function<QString(Pilot*)> > placeholders;
 
         enum FlightStatus {
             BOARDING, GROUND_DEP, DEPARTING, EN_ROUTE, ARRIVING,
@@ -32,7 +32,7 @@ class Pilot
         virtual QString mapLabelHovered() const override;
         virtual QStringList mapLabelSecondaryLines() const override;
         virtual QStringList mapLabelSecondaryLinesHovered() const override;
-        virtual QString livestreamString(bool shortened = false) const override;
+        virtual QString livestreamString() const override;
         virtual bool hasPrimaryAction() const override;
         virtual void primaryAction() override;
 
@@ -82,7 +82,6 @@ class Pilot
         QDateTime whazzupTime; // need some local reference to that
         QList<Waypoint*> routeWaypointsCache; // caching calculated routeWaypoints
         Airline* airline;
-    private:
 };
 
 #endif /*PILOT_H_*/

--- a/src/QuteScoop.cpp
+++ b/src/QuteScoop.cpp
@@ -138,7 +138,6 @@ int main(int argc, char* argv[]) {
             if (!airways.isEmpty()) {
                 QTextStream(stdout) << "\tairways: " << airways.join(", ") << Qt::endl;
             }
-
         }
 
         return 0;
@@ -147,10 +146,6 @@ int main(int argc, char* argv[]) {
     // show Launcher
     Launcher::instance()->fireUp();
 
-    QMessageLogger("ile.constData()", 43, 0).debug() << "lkiij";
-
     // start event loop
-    int ret = app.exec();
-
-    return ret;
+    return app.exec();
 }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -767,7 +767,7 @@ void Settings::setFirPrimaryContentHovered(const QString &value) {
 }
 
 QString Settings::firSecondaryContent() {
-    return instance()->value("firDisplay/secondaryContent", "{cpdlc-}\n{livestream}").toString();
+    return instance()->value("firDisplay/secondaryContent", "{#cpdlc}@{cpdlc}{/cpdlc}{#livestream}📺{/livestream}").toString();
 }
 
 void Settings::setFirSecondaryContent(const QString &value) {
@@ -775,7 +775,7 @@ void Settings::setFirSecondaryContent(const QString &value) {
 }
 
 QString Settings::firSecondaryContentHovered() {
-    return instance()->value("firDisplay/secondaryContentHovered", "{frequency}\n{cpdlc}\n{livestream}").toString();
+    return instance()->value("firDisplay/secondaryContentHovered", "{#cpdlc}CPDLC@{cpdlc}{/cpdlc}\n{sector} {frequency}\n{name} {rating}\n{livestream}").toString();
 }
 
 void Settings::setFirSecondaryContentHovered(const QString &value) {
@@ -825,7 +825,7 @@ void Settings::setAirportFontSecondaryColor(const QColor& color) {
 }
 
 QString Settings::airportPrimaryContent() {
-    return instance()->value("airportDisplay/primaryContent", "{code} {traffic}").toString();
+    return instance()->value("airportDisplay/primaryContent", "{code}{#pdc}@{/pdc} {> trafficArrows} {#livestream}📺{/livestream}").toString();
 }
 
 void Settings::setAirportPrimaryContent(const QString &value) {
@@ -833,7 +833,7 @@ void Settings::setAirportPrimaryContent(const QString &value) {
 }
 
 QString Settings::airportPrimaryContentHovered() {
-    return instance()->value("airportDisplay/primaryContentHovered", "{code} {traffic}").toString();
+    return instance()->value("airportDisplay/primaryContentHovered", "{code}{#pdc}@{/pdc} {> trafficArrows} {#livestream}📺{/livestream}").toString();
 }
 
 void Settings::setAirportPrimaryContentHovered(const QString &value) {
@@ -841,7 +841,7 @@ void Settings::setAirportPrimaryContentHovered(const QString &value) {
 }
 
 QString Settings::airportSecondaryContent() {
-    return instance()->value("airportDisplay/secondaryContent", "{pdc-}\n{livestream}").toString();
+    return instance()->value("airportDisplay/secondaryContent", "").toString();
 }
 
 void Settings::setAirportSecondaryContent(const QString &value) {
@@ -849,7 +849,7 @@ void Settings::setAirportSecondaryContent(const QString &value) {
 }
 
 QString Settings::airportSecondaryContentHovered() {
-    return instance()->value("airportDisplay/secondaryContentHovered", "{prettyName}\n{pdc}\n{frequencies}\n{livestream}").toString();
+    return instance()->value("airportDisplay/secondaryContentHovered", "{prettyName}\n{#pdc}PDC@{pdc}{/pdc}\n{frequencies}\n{livestream}").toString();
 }
 
 void Settings::setAirportSecondaryContentHovered(const QString &value) {
@@ -1184,7 +1184,7 @@ void Settings::setPilotPrimaryContentHovered(const QString &value) {
 }
 
 QString Settings::pilotSecondaryContent() {
-    return instance()->value("pilotDisplay/secondaryContent", "{rating}\n{livestream}").toString();
+    return instance()->value("pilotDisplay/secondaryContent", "{rating} {#livestream}📺{/livestream}").toString();
 }
 
 void Settings::setPilotSecondaryContent(const QString &value) {

--- a/src/dialogs/PreferencesDialog.ui
+++ b/src/dialogs/PreferencesDialog.ui
@@ -1383,19 +1383,6 @@ The texture is affected by the colour chosen for the Globe.</string>
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
              <layout class="QGridLayout" name="gridLayout_21">
-              <item row="1" column="4">
-               <spacer name="horizontalSpacer_27">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
               <item row="1" column="0">
                <widget class="QLabel" name="label_104">
                 <property name="text">
@@ -1414,25 +1401,6 @@ TWR: 133.375</string>
                 </property>
                 <property name="flat">
                  <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1" colspan="3">
-               <widget class="QPlainTextEdit" name="plainTextEditAirportSecondaryContent">
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>50</height>
-                 </size>
-                </property>
-                <property name="sizeAdjustPolicy">
-                 <enum>QAbstractScrollArea::AdjustIgnored</enum>
-                </property>
-                <property name="lineWrapMode">
-                 <enum>QPlainTextEdit::NoWrap</enum>
-                </property>
-                <property name="plainText">
-                 <string>{traffic} {controllers}</string>
                 </property>
                </widget>
               </item>
@@ -1477,7 +1445,26 @@ TWR: 133.375</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1" colspan="3">
+              <item row="1" column="1" colspan="4">
+               <widget class="QPlainTextEdit" name="plainTextEditAirportSecondaryContent">
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>50</height>
+                 </size>
+                </property>
+                <property name="sizeAdjustPolicy">
+                 <enum>QAbstractScrollArea::AdjustIgnored</enum>
+                </property>
+                <property name="lineWrapMode">
+                 <enum>QPlainTextEdit::NoWrap</enum>
+                </property>
+                <property name="plainText">
+                 <string>{traffic} {controllers}</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1" colspan="4">
                <widget class="QPlainTextEdit" name="plainTextEditAirportSecondaryContentHovered">
                 <property name="maximumSize">
                  <size>
@@ -1507,9 +1494,9 @@ TWR: 133.375</string>
             <property name="geometry">
              <rect>
               <x>0</x>
-              <y>-97</y>
-              <width>469</width>
-              <height>715</height>
+              <y>0</y>
+              <width>512</width>
+              <height>772</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -1532,6 +1519,16 @@ TWR: 133.375</string>
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_9">
                 <item>
+                 <widget class="QLabel" name="label_172">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This supports the simple template language &lt;a href=&quot;https://mustache.github.io/mustache.5.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;{ mustache }&lt;/span&gt;&lt;/a&gt;. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="openExternalLinks">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QWidget" name="widget_10" native="true">
                   <layout class="QGridLayout" name="gridLayout_20">
                    <property name="leftMargin">
@@ -1546,47 +1543,24 @@ TWR: 133.375</string>
                    <property name="bottomMargin">
                     <number>0</number>
                    </property>
-                   <item row="4" column="2">
-                    <widget class="QLabel" name="label_107">
+                   <item row="4" column="0">
+                    <widget class="QLabel" name="label_102">
                      <property name="text">
-                      <string># + all
-inbound/outbounds 
-currently connected</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="6" column="3">
-                    <widget class="QLabel" name="label_90">
-                     <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;ATIS: H or&lt;br/&gt;ATIS_D: J, _A: X or&lt;br/&gt;ATIS: ?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="12" column="0">
-                    <widget class="QLabel" name="label_117">
-                     <property name="text">
-                      <string>{pdc}</string>
+                      <string>{code}</string>
                      </property>
                      <property name="textInteractionFlags">
                       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                      </property>
                     </widget>
                    </item>
-                   <item row="7" column="3">
+                   <item row="9" column="3">
                     <widget class="QLabel" name="label_100">
                      <property name="text">
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;CA&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="12" column="3">
-                    <widget class="QLabel" name="label_119">
-                     <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;PDC@EDDB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="11" column="2">
+                   <item row="13" column="2">
                     <widget class="QLabel" name="label_109">
                      <property name="text">
                       <string>abreviated list of
@@ -1596,79 +1570,52 @@ with controller suffixes
                      </property>
                     </widget>
                    </item>
-                   <item row="5" column="2">
-                    <widget class="QLabel" name="label_85">
+                   <item row="6" column="2">
+                    <widget class="QLabel" name="label_107">
                      <property name="text">
-                      <string>active controllers
-at this aerodrome
-(by type)</string>
+                      <string>all arrivals/departures
+(unfiltered)</string>
                      </property>
                     </widget>
                    </item>
                    <item row="5" column="3">
-                    <widget class="QLabel" name="label_89">
+                    <widget class="QLabel" name="label_80">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;D,G,T,A&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="9" column="3">
-                    <widget class="QLabel" name="label_113">
+                   <item row="10" column="3">
+                    <widget class="QLabel" name="label_83">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Adnan Menderes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Berlin Brandenburg Intl or&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Adnan Menderes, Izmir&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="13" column="0">
-                    <widget class="QLabel" name="label_169">
+                   <item row="10" column="0">
+                    <widget class="QLabel" name="label_101">
                      <property name="text">
-                      <string>{pdc-}</string>
+                      <string>{prettyName}</string>
                      </property>
                      <property name="textInteractionFlags">
                       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                      </property>
                     </widget>
                    </item>
-                   <item row="11" column="3">
-                    <widget class="QLabel" name="label_110">
+                   <item row="7" column="3">
+                    <widget class="QLabel" name="label_89">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;ATIS: 121.975: X&lt;br/&gt;GND: 121.850&lt;br/&gt;TWR: 118.625_N, 119.900_S&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;D,G,T,A&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="2" column="2">
-                    <widget class="QLabel" name="label_84">
+                   <item row="5" column="0">
+                    <widget class="QLabel" name="label_98">
                      <property name="text">
-                      <string>aerodrome code</string>
+                      <string>{arrs} / {deps}</string>
                      </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="2">
-                    <widget class="QLabel" name="label_99">
-                     <property name="text">
-                      <string>arrivals / departures
-(applies the traffic 
-visualization filter 
-if selected)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_92">
-                     <property name="font">
-                      <font>
-                       <bold>true</bold>
-                      </font>
-                     </property>
-                     <property name="text">
-                      <string>placeholder</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="8" column="3">
-                    <widget class="QLabel" name="label_83">
-                     <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Berlin Brandenburg Intl or&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Adnan Menderes, Izmir&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                      </property>
                     </widget>
                    </item>
@@ -1679,113 +1626,44 @@ if selected)</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_98">
-                     <property name="text">
-                      <string>{traffic}</string>
-                     </property>
-                     <property name="textInteractionFlags">
-                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="8" column="2">
-                    <widget class="QLabel" name="label_93">
-                     <property name="text">
-                      <string>aerodrome name
-(and city, but only if city is
-not included in the name
-already)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="13" column="3">
-                    <widget class="QLabel" name="label_171">
-                     <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;@ or&lt;br/&gt;@EKCX&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="10" column="0">
-                    <widget class="QLabel" name="label_81">
-                     <property name="text">
-                      <string>{city}</string>
-                     </property>
-                     <property name="textInteractionFlags">
-                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="3">
-                    <widget class="QLabel" name="label_80">
-                     <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;-/2&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="6" column="0">
-                    <widget class="QLabel" name="label_87">
-                     <property name="text">
-                      <string>{atis}</string>
-                     </property>
-                     <property name="textInteractionFlags">
-                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_102">
-                     <property name="text">
-                      <string>{code}</string>
-                     </property>
-                     <property name="textInteractionFlags">
-                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="15" column="3">
+                   <item row="16" column="3">
                     <widget class="QLabel" name="label_161">
                      <property name="text">
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;twitch/username&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="10" column="3">
-                    <widget class="QLabel" name="label_91">
+                   <item row="4" column="3">
+                    <widget class="QLabel" name="label_103">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Berlin&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;LGAV&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="13" column="2">
-                    <widget class="QLabel" name="label_170">
+                   <item row="7" column="0">
+                    <widget class="QLabel" name="label_96">
                      <property name="text">
-                      <string>@ + logon, but only if
-different from airport code</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="0">
-                    <widget class="QLabel" name="label_95">
-                     <property name="text">
-                      <string>{trafficUnfiltered}</string>
+                      <string>{controllers}</string>
                      </property>
                      <property name="textInteractionFlags">
                       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                      </property>
                     </widget>
                    </item>
-                   <item row="9" column="2">
-                    <widget class="QLabel" name="label_112">
+                   <item row="5" column="2">
+                    <widget class="QLabel" name="label_99">
                      <property name="text">
-                      <string>aerodrome name</string>
+                      <string>arrivals / departures
+(applies the traffic 
+visualization filter 
+if selected)</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="11" column="0">
-                    <widget class="QLabel" name="label_108">
+                   <item row="16" column="0">
+                    <widget class="QLabel" name="label_158">
                      <property name="text">
-                      <string>{frequencies}</string>
+                      <string>{livestream}</string>
                      </property>
                      <property name="textInteractionFlags">
                       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -1804,48 +1682,14 @@ different from airport code</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="4" column="3">
-                    <widget class="QLabel" name="label_94">
+                   <item row="13" column="3">
+                    <widget class="QLabel" name="label_110">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;#112/70&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;ATIS: 121.975: X&lt;br/&gt;GND: 121.850&lt;br/&gt;TWR: 118.625_N, 119.900_S&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="9" column="0">
-                    <widget class="QLabel" name="label_111">
-                     <property name="text">
-                      <string>{name}</string>
-                     </property>
-                     <property name="textInteractionFlags">
-                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="15" column="2">
-                    <widget class="QLabel" name="label_162">
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="3">
-                    <widget class="QLabel" name="label_103">
-                     <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;LGAV&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="5" column="0">
-                    <widget class="QLabel" name="label_96">
-                     <property name="text">
-                      <string>{controllers}</string>
-                     </property>
-                     <property name="textInteractionFlags">
-                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="6" column="2">
+                   <item row="8" column="2">
                     <widget class="QLabel" name="label_88">
                      <property name="text">
                       <string>ATIS: letter or ? 
@@ -1854,17 +1698,89 @@ letter unknown</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="15" column="0">
-                    <widget class="QLabel" name="label_158">
+                   <item row="6" column="3">
+                    <widget class="QLabel" name="label_94">
                      <property name="text">
-                      <string>{livestream}</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;13&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="4" column="2">
+                    <widget class="QLabel" name="label_84">
+                     <property name="text">
+                      <string>aerodrome code</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="10" column="2">
+                    <widget class="QLabel" name="label_93">
+                     <property name="text">
+                      <string>aerodrome name
+(and city, but only if city is
+not included in the name
+already)</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="0">
+                    <widget class="QLabel" name="label_95">
+                     <property name="text">
+                      <string>{allArrs} / {allDeps}</string>
                      </property>
                      <property name="textInteractionFlags">
                       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                      </property>
                     </widget>
                    </item>
-                   <item row="7" column="0">
+                   <item row="12" column="0">
+                    <widget class="QLabel" name="label_81">
+                     <property name="text">
+                      <string>{city}</string>
+                     </property>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="14" column="3">
+                    <widget class="QLabel" name="label_119">
+                     <property name="text">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;EDDB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="11" column="3">
+                    <widget class="QLabel" name="label_113">
+                     <property name="text">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Adnan Menderes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="16" column="2">
+                    <widget class="QLabel" name="label_162">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="14" column="2">
+                    <widget class="QLabel" name="label_118">
+                     <property name="text">
+                      <string>Hoppie logon of PDC
+station. This is a guess
+based on controller 
+infos.</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="12" column="3">
+                    <widget class="QLabel" name="label_91">
+                     <property name="text">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Berlin&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="9" column="0">
                     <widget class="QLabel" name="label_97">
                      <property name="text">
                       <string>{country}</string>
@@ -1875,46 +1791,135 @@ letter unknown</string>
                     </widget>
                    </item>
                    <item row="8" column="0">
-                    <widget class="QLabel" name="label_101">
+                    <widget class="QLabel" name="label_87">
                      <property name="text">
-                      <string>{prettyName}</string>
+                      <string>{atis}</string>
                      </property>
                      <property name="textInteractionFlags">
                       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                      </property>
                     </widget>
                    </item>
-                   <item row="12" column="2">
-                    <widget class="QLabel" name="label_118">
+                   <item row="11" column="2">
+                    <widget class="QLabel" name="label_112">
                      <property name="text">
-                      <string>Hoppie logon of PDC
-station. This is a guess
-based on controller 
-infos.</string>
+                      <string>aerodrome name</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="16" column="0">
+                   <item row="8" column="3">
+                    <widget class="QLabel" name="label_90">
+                     <property name="text">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;ATIS: H or&lt;br/&gt;ATIS_D: J, _A: X or&lt;br/&gt;ATIS: ?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="14" column="0">
+                    <widget class="QLabel" name="label_117">
+                     <property name="text">
+                      <string>{pdc}</string>
+                     </property>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="11" column="0">
+                    <widget class="QLabel" name="label_111">
+                     <property name="text">
+                      <string>{name}</string>
+                     </property>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="0">
+                    <widget class="QLabel" name="label_92">
+                     <property name="font">
+                      <font>
+                       <bold>true</bold>
+                      </font>
+                     </property>
+                     <property name="text">
+                      <string>placeholder</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="13" column="0">
+                    <widget class="QLabel" name="label_108">
+                     <property name="text">
+                      <string>{frequencies}</string>
+                     </property>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="7" column="2">
+                    <widget class="QLabel" name="label_85">
+                     <property name="text">
+                      <string>active controllers
+at this aerodrome
+(by type)</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="0">
+                    <widget class="QLabel" name="label_169">
+                     <property name="text">
+                      <string>{&gt; traffic}</string>
+                     </property>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="0">
+                    <widget class="QLabel" name="label_170">
+                     <property name="text">
+                      <string>{&gt; trafficArrows}</string>
+                     </property>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="2">
+                    <widget class="QLabel" name="label_171">
+                     <property name="text">
+                      <string>Short hand for
+{#arrs}{arrs}{/arrs}{^arrs}-{/arrs}/
+{#deps}{deps}{/deps}{^deps}-{/deps}</string>
+                     </property>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="3">
                     <widget class="QLabel" name="label_175">
                      <property name="text">
-                      <string>{livestream-}</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;5/16 or&lt;br/&gt;-/5&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="2">
+                    <widget class="QLabel" name="label_176">
+                     <property name="text">
+                      <string>Short hand for
+{#arrs}{arrs}↘{/arrs}
+{#deps}↗{deps}{/deps}</string>
                      </property>
                      <property name="textInteractionFlags">
                       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                      </property>
                     </widget>
                    </item>
-                   <item row="16" column="2">
-                    <widget class="QLabel" name="label_176">
-                     <property name="text">
-                      <string>only ~</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="16" column="3">
+                   <item row="3" column="3">
                     <widget class="QLabel" name="label_177">
                      <property name="text">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;~&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;5↘↗16 or&lt;br/&gt;↗5&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
@@ -2259,13 +2264,6 @@ margin</string>
             <string>Primary label (first line)</string>
            </property>
            <layout class="QGridLayout" name="gridLayout_11">
-            <item row="2" column="1" colspan="5">
-             <widget class="QLineEdit" name="lineEditAirportPrimaryContent">
-              <property name="text">
-               <string>{code}</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="8">
              <widget class="QPushButton" name="pbAirportDotColor">
               <property name="autoFillBackground">
@@ -2365,13 +2363,6 @@ active</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="1" colspan="5">
-             <widget class="QLineEdit" name="lineEditAirportPrimaryContentHovered">
-              <property name="text">
-               <string>{code}</string>
-              </property>
-             </widget>
-            </item>
             <item row="1" column="1">
              <widget class="QPushButton" name="pbInactAirportFontColor">
               <property name="toolTip">
@@ -2458,6 +2449,20 @@ no controllers)</string>
                </size>
               </property>
              </spacer>
+            </item>
+            <item row="2" column="1" colspan="9">
+             <widget class="QLineEdit" name="lineEditAirportPrimaryContent">
+              <property name="text">
+               <string>{code}</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1" colspan="9">
+             <widget class="QLineEdit" name="lineEditAirportPrimaryContentHovered">
+              <property name="text">
+               <string>{code}</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>
@@ -2918,7 +2923,45 @@ or arriving in </string>
            <layout class="QVBoxLayout" name="verticalLayout_17">
             <item>
              <layout class="QGridLayout" name="gridLayout_6">
-              <item row="0" column="3" colspan="3">
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_77">
+                <property name="text">
+                 <string>content
+(hovered)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_74">
+                <property name="text">
+                 <string>content</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPushButton" name="pbPilotFontColor">
+                <property name="autoFillBackground">
+                 <bool>true</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QPushButton" name="pbPilotFont">
+                <property name="autoFillBackground">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>UPS5GH</string>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3" colspan="2">
                <spacer name="horizontalSpacer_10">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
@@ -2941,65 +2984,14 @@ or arriving in </string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QPushButton" name="pbPilotFontColor">
-                <property name="autoFillBackground">
-                 <bool>true</bool>
-                </property>
-                <property name="flat">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="4" colspan="2">
-               <spacer name="horizontalSpacer_22">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="1" column="1" colspan="3">
+              <item row="1" column="1" colspan="4">
                <widget class="QLineEdit" name="lineEditPilotPrimaryContent">
                 <property name="text">
                  <string>{login}</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="2">
-               <widget class="QPushButton" name="pbPilotFont">
-                <property name="autoFillBackground">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string>UPS5GH</string>
-                </property>
-                <property name="flat">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_74">
-                <property name="text">
-                 <string>content</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_77">
-                <property name="text">
-                 <string>content
-(hovered)</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1" colspan="3">
+              <item row="2" column="1" colspan="4">
                <widget class="QLineEdit" name="lineEditPilotPrimaryContentHovered">
                 <property name="text">
                  <string>{login}</string>
@@ -3019,19 +3011,6 @@ or arriving in </string>
            <layout class="QVBoxLayout" name="verticalLayout_21">
             <item>
              <layout class="QGridLayout" name="gridLayout_16">
-              <item row="1" column="4">
-               <spacer name="horizontalSpacer_21">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
               <item row="1" column="0">
                <widget class="QLabel" name="label_18">
                 <property name="text">
@@ -3050,25 +3029,6 @@ B738 EGLL</string>
                 </property>
                 <property name="flat">
                  <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1" colspan="3">
-               <widget class="QPlainTextEdit" name="plainTextEditPilotSecondaryContent">
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>50</height>
-                 </size>
-                </property>
-                <property name="sizeAdjustPolicy">
-                 <enum>QAbstractScrollArea::AdjustIgnored</enum>
-                </property>
-                <property name="lineWrapMode">
-                 <enum>QPlainTextEdit::NoWrap</enum>
-                </property>
-                <property name="plainText">
-                 <string>{FL} {GS}</string>
                 </property>
                </widget>
               </item>
@@ -3113,7 +3073,26 @@ B738 EGLL</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1" colspan="3">
+              <item row="1" column="1" colspan="4">
+               <widget class="QPlainTextEdit" name="plainTextEditPilotSecondaryContent">
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>50</height>
+                 </size>
+                </property>
+                <property name="sizeAdjustPolicy">
+                 <enum>QAbstractScrollArea::AdjustIgnored</enum>
+                </property>
+                <property name="lineWrapMode">
+                 <enum>QPlainTextEdit::NoWrap</enum>
+                </property>
+                <property name="plainText">
+                 <string>{FL} {GS}</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1" colspan="4">
                <widget class="QPlainTextEdit" name="plainTextEditPilotSecondaryContentHovered">
                 <property name="maximumSize">
                  <size>
@@ -3334,6 +3313,16 @@ color and strength</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_6">
             <item>
+             <widget class="QLabel" name="label_173">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This supports the simple template language &lt;a href=&quot;https://mustache.github.io/mustache.5.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;{ mustache }&lt;/span&gt;&lt;/a&gt;. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="openExternalLinks">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QWidget" name="widget_9" native="true">
               <layout class="QGridLayout" name="gridLayout_18">
                <property name="leftMargin">
@@ -3348,111 +3337,13 @@ color and strength</string>
                <property name="bottomMargin">
                 <number>0</number>
                </property>
-               <item row="10" column="2">
-                <widget class="QLabel" name="label_68">
+               <item row="13" column="0">
+                <widget class="QLabel" name="label_70">
                  <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;N43&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="0">
-                <widget class="QLabel" name="label_43">
-                 <property name="text">
-                  <string>{FL}</string>
+                  <string>{type}</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="1">
-                <widget class="QLabel" name="label_61">
-                 <property name="text">
-                  <string>destination aerodrome</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="2">
-                <widget class="QLabel" name="label_155">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;V&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="2">
-                <widget class="QLabel" name="label_69">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;F290&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QLabel" name="label_54">
-                 <property name="font">
-                  <font>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;example output&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0">
-                <widget class="QLabel" name="label_56">
-                 <property name="text">
-                  <string>{dest}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="1">
-                <widget class="QLabel" name="label_64">
-                 <property name="text">
-                  <string>N+ground speed [kts]</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="2">
-                <widget class="QLabel" name="label_160">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;twitch/username&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="2">
-                <widget class="QLabel" name="label_137">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;PPL&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="label_42">
-                 <property name="text">
-                  <string>{dep}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="1">
-                <widget class="QLabel" name="label_136">
-                 <property name="text">
-                  <string>VATSIM pilot ranking
-(NEW is not shown)
- + military rating
-(M0 is not shown)</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0" colspan="3">
-                <widget class="Line" name="line_4">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
                  </property>
                 </widget>
                </item>
@@ -3460,70 +3351,6 @@ color and strength</string>
                 <widget class="QLabel" name="label_65">
                  <property name="text">
                   <string>{GS10}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="2">
-                <widget class="QLabel" name="label_76">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;BTI660&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="0">
-                <widget class="QLabel" name="label_156">
-                 <property name="text">
-                  <string>{livestream}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_53">
-                 <property name="font">
-                  <font>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>placeholder</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="0">
-                <widget class="QLabel" name="label_153">
-                 <property name="text">
-                  <string>{rulesIfNotIfr}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="2">
-                <widget class="QLabel" name="label_67">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;N426&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="QLabel" name="label_34">
-                 <property name="text">
-                  <string>like {name}, but 
-only if in friends list</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_28">
-                 <property name="text">
-                  <string>{nameIfFriend}</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -3550,10 +3377,91 @@ only if in friends list</string>
                  </property>
                 </widget>
                </item>
+               <item row="13" column="1">
+                <widget class="QLabel" name="label_71">
+                 <property name="text">
+                  <string>aircraft type</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="label_63">
+                 <property name="text">
+                  <string>F+flight level</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="2">
+                <widget class="QLabel" name="label_72">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;BCS3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="label_60">
+                 <property name="text">
+                  <string>departure aerodrome</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="2">
+                <widget class="QLabel" name="label_68">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;N43&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_42">
+                 <property name="text">
+                  <string>{dep}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0" colspan="3">
+                <widget class="Line" name="line_4">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="2">
+                <widget class="QLabel" name="label_51">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;I&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_53">
+                 <property name="font">
+                  <font>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>placeholder</string>
+                 </property>
+                </widget>
+               </item>
                <item row="12" column="1">
                 <widget class="QLabel" name="label_154">
                  <property name="text">
                   <string>like {rules}, but not I</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="label_56">
+                 <property name="text">
+                  <string>{dest}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                  </property>
                 </widget>
                </item>
@@ -3567,27 +3475,25 @@ only if in friends list</string>
                  </property>
                 </widget>
                </item>
-               <item row="8" column="1">
-                <widget class="QLabel" name="label_63">
+               <item row="7" column="1">
+                <widget class="QLabel" name="label_61">
                  <property name="text">
-                  <string>F+flight level</string>
+                  <string>destination aerodrome</string>
                  </property>
                 </widget>
                </item>
-               <item row="9" column="0">
-                <widget class="QLabel" name="label_62">
+               <item row="4" column="1">
+                <widget class="QLabel" name="label_34">
                  <property name="text">
-                  <string>{GS}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                  <string>like {name}, but 
+only if in friends list</string>
                  </property>
                 </widget>
                </item>
-               <item row="13" column="2">
-                <widget class="QLabel" name="label_72">
+               <item row="11" column="1">
+                <widget class="QLabel" name="label_48">
                  <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;BCS3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>flight plan rules [I/V/Y/Z/S]</string>
                  </property>
                 </widget>
                </item>
@@ -3601,17 +3507,20 @@ only if in friends list</string>
                  </property>
                 </widget>
                </item>
-               <item row="6" column="1">
-                <widget class="QLabel" name="label_60">
+               <item row="2" column="2">
+                <widget class="QLabel" name="label_76">
                  <property name="text">
-                  <string>departure aerodrome</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;BTI660&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
-               <item row="13" column="1">
-                <widget class="QLabel" name="label_71">
+               <item row="5" column="1">
+                <widget class="QLabel" name="label_136">
                  <property name="text">
-                  <string>aircraft type</string>
+                  <string>VATSIM pilot ranking
+(NEW is not shown)
+ + military rating
+(M0 is not shown)</string>
                  </property>
                 </widget>
                </item>
@@ -3622,20 +3531,42 @@ only if in friends list</string>
                  </property>
                 </widget>
                </item>
-               <item row="13" column="0">
-                <widget class="QLabel" name="label_70">
+               <item row="14" column="0">
+                <widget class="QLabel" name="label_156">
                  <property name="text">
-                  <string>{type}</string>
+                  <string>{livestream}</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                  </property>
                 </widget>
                </item>
-               <item row="11" column="2">
-                <widget class="QLabel" name="label_51">
+               <item row="0" column="2">
+                <widget class="QLabel" name="label_54">
+                 <property name="font">
+                  <font>
+                   <bold>true</bold>
+                  </font>
+                 </property>
                  <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;I&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;example output&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="label_62">
+                 <property name="text">
+                  <string>{GS}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="2">
+                <widget class="QLabel" name="label_160">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;twitch/username&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
@@ -3647,6 +3578,20 @@ only if in friends list</string>
                  </property>
                 </widget>
                </item>
+               <item row="5" column="2">
+                <widget class="QLabel" name="label_137">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;PPL&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="label_64">
+                 <property name="text">
+                  <string>N+ground speed [kts]</string>
+                 </property>
+                </widget>
+               </item>
                <item row="10" column="1">
                 <widget class="QLabel" name="label_66">
                  <property name="text">
@@ -3655,24 +3600,54 @@ tens [10kts]</string>
                  </property>
                 </widget>
                </item>
-               <item row="11" column="1">
-                <widget class="QLabel" name="label_48">
+               <item row="8" column="0">
+                <widget class="QLabel" name="label_43">
                  <property name="text">
-                  <string>flight plan rules [I/V/Y/Z/S]</string>
+                  <string>{FL}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                  </property>
                 </widget>
                </item>
-               <item row="15" column="0">
-                <widget class="QLabel" name="label_178">
+               <item row="8" column="2">
+                <widget class="QLabel" name="label_69">
                  <property name="text">
-                  <string>{livestream-}</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;F290&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
-               <item row="15" column="2">
-                <widget class="QLabel" name="label_179">
+               <item row="9" column="2">
+                <widget class="QLabel" name="label_67">
                  <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;~&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;N426&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="2">
+                <widget class="QLabel" name="label_155">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;V&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="0">
+                <widget class="QLabel" name="label_153">
+                 <property name="text">
+                  <string>{rulesIfNotIfr}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_28">
+                 <property name="text">
+                  <string>{nameIfFriend}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                  </property>
                 </widget>
                </item>
@@ -4096,19 +4071,6 @@ part directly in front of aircraft)</string>
            <layout class="QVBoxLayout" name="verticalLayout_25">
             <item>
              <layout class="QGridLayout" name="gridLayout_29">
-              <item row="1" column="4">
-               <spacer name="horizontalSpacer_31">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
               <item row="1" column="0">
                <widget class="QLabel" name="label_129">
                 <property name="text">
@@ -4127,25 +4089,6 @@ CPDLC/EDGP</string>
                 </property>
                 <property name="flat">
                  <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1" colspan="3">
-               <widget class="QPlainTextEdit" name="plainTextEditFirSecondaryContent">
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>50</height>
-                 </size>
-                </property>
-                <property name="sizeAdjustPolicy">
-                 <enum>QAbstractScrollArea::AdjustIgnored</enum>
-                </property>
-                <property name="lineWrapMode">
-                 <enum>QPlainTextEdit::NoWrap</enum>
-                </property>
-                <property name="plainText">
-                 <string>{FL} {GS}</string>
                 </property>
                </widget>
               </item>
@@ -4190,7 +4133,26 @@ CPDLC/EDGP</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1" colspan="3">
+              <item row="1" column="1" colspan="4">
+               <widget class="QPlainTextEdit" name="plainTextEditFirSecondaryContent">
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>50</height>
+                 </size>
+                </property>
+                <property name="sizeAdjustPolicy">
+                 <enum>QAbstractScrollArea::AdjustIgnored</enum>
+                </property>
+                <property name="lineWrapMode">
+                 <enum>QPlainTextEdit::NoWrap</enum>
+                </property>
+                <property name="plainText">
+                 <string>{FL} {GS}</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1" colspan="4">
                <widget class="QPlainTextEdit" name="plainTextEditFirSecondaryContentHovered">
                 <property name="maximumSize">
                  <size>
@@ -4220,7 +4182,24 @@ CPDLC/EDGP</string>
            <layout class="QVBoxLayout" name="verticalLayout_23">
             <item>
              <layout class="QGridLayout" name="gridLayout_28">
-              <item row="0" column="3" colspan="3">
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_126">
+                <property name="text">
+                 <string>font</string>
+                </property>
+                <property name="buddy">
+                 <cstring>pbPilotFontColor</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_127">
+                <property name="text">
+                 <string>content</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3" colspan="2">
                <spacer name="horizontalSpacer_29">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
@@ -4232,46 +4211,6 @@ CPDLC/EDGP</string>
                  </size>
                 </property>
                </spacer>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_126">
-                <property name="text">
-                 <string>font</string>
-                </property>
-                <property name="buddy">
-                 <cstring>pbPilotFontColor</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QPushButton" name="pbFirFontColor">
-                <property name="autoFillBackground">
-                 <bool>true</bool>
-                </property>
-                <property name="flat">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="4" colspan="2">
-               <spacer name="horizontalSpacer_30">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="1" column="1" colspan="3">
-               <widget class="QLineEdit" name="lineEditFirPrimaryContent">
-                <property name="text">
-                 <string>{login}</string>
-                </property>
-               </widget>
               </item>
               <item row="0" column="2">
                <widget class="QPushButton" name="pbFirFont">
@@ -4286,13 +4225,6 @@ CPDLC/EDGP</string>
                 </property>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_127">
-                <property name="text">
-                 <string>content</string>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="0">
                <widget class="QLabel" name="label_128">
                 <property name="text">
@@ -4301,7 +4233,24 @@ CPDLC/EDGP</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1" colspan="3">
+              <item row="0" column="1">
+               <widget class="QPushButton" name="pbFirFontColor">
+                <property name="autoFillBackground">
+                 <bool>true</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1" colspan="4">
+               <widget class="QLineEdit" name="lineEditFirPrimaryContent">
+                <property name="text">
+                 <string>{login}</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1" colspan="4">
                <widget class="QLineEdit" name="lineEditFirPrimaryContentHovered">
                 <property name="text">
                  <string>{login}</string>
@@ -4486,6 +4435,16 @@ CPDLC/EDGP</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_24">
             <item>
+             <widget class="QLabel" name="label_174">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This supports the simple template language &lt;a href=&quot;https://mustache.github.io/mustache.5.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;{ mustache }&lt;/span&gt;&lt;/a&gt;. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="openExternalLinks">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QWidget" name="widget_11" native="true">
               <layout class="QGridLayout" name="gridLayout_23">
                <property name="leftMargin">
@@ -4500,79 +4459,6 @@ CPDLC/EDGP</string>
                <property name="bottomMargin">
                 <number>0</number>
                </property>
-               <item row="9" column="0">
-                <widget class="QLabel" name="label_172">
-                 <property name="text">
-                  <string>{cpdlc-}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="2">
-                <widget class="QLabel" name="label_148">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Langen DKB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_147">
-                 <property name="text">
-                  <string>{name}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="0">
-                <widget class="QLabel" name="label_131">
-                 <property name="text">
-                  <string>{cpdlc}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="label_141">
-                 <property name="text">
-                  <string>{rating}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="1">
-                <widget class="QLabel" name="label_173">
-                 <property name="text">
-                  <string>only @ + logon, but
-only if different
-than controller login</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="0">
-                <widget class="QLabel" name="label_157">
-                 <property name="text">
-                  <string>{livestream}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="2">
-                <widget class="QLabel" name="label_138">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;CPDLC@EDWA&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
                <item row="4" column="1">
                 <widget class="QLabel" name="label_149">
                  <property name="text">
@@ -4589,13 +4475,43 @@ only if in friends list</string>
                  </property>
                 </widget>
                </item>
-               <item row="8" column="1">
-                <widget class="QLabel" name="label_144">
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_125">
                  <property name="text">
-                  <string>Hoppie logon of CPDLC
-station. This is a guess
-based on the controller 
-info.</string>
+                  <string>{sectorOrLogin}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_147">
+                 <property name="text">
+                  <string>{name}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="label_145">
+                 <property name="text">
+                  <string>{frequency}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="label_131">
+                 <property name="text">
+                  <string>{cpdlc}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                  </property>
                 </widget>
                </item>
@@ -4606,7 +4522,36 @@ info.</string>
                  </property>
                 </widget>
                </item>
-               <item row="12" column="1">
+               <item row="1" column="0" colspan="3">
+                <widget class="Line" name="line_6">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QLabel" name="label_124">
+                 <property name="font">
+                  <font>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;example output&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_86">
+                 <property name="text">
+                  <string>{sector}</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
                 <spacer name="verticalSpacer_8">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
@@ -4626,39 +4571,13 @@ info.</string>
                  </property>
                 </widget>
                </item>
-               <item row="7" column="2">
-                <widget class="QLabel" name="label_139">
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_141">
                  <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;123.925&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="2">
-                <widget class="QLabel" name="label_174">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;@ or&lt;br/&gt;@EKDK&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="label_86">
-                 <property name="text">
-                  <string>{sector}</string>
+                  <string>{rating}</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QLabel" name="label_124">
-                 <property name="font">
-                  <font>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;example output&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
@@ -4674,6 +4593,23 @@ info.</string>
                  </property>
                 </widget>
                </item>
+               <item row="8" column="2">
+                <widget class="QLabel" name="label_138">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;EDWA&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="label_144">
+                 <property name="text">
+                  <string>Hoppie logon of CPDLC
+station. This is a guess
+based on the controller 
+info.</string>
+                 </property>
+                </widget>
+               </item>
                <item row="5" column="0">
                 <widget class="QLabel" name="label_143">
                  <property name="text">
@@ -4684,23 +4620,24 @@ info.</string>
                  </property>
                 </widget>
                </item>
-               <item row="7" column="0">
-                <widget class="QLabel" name="label_145">
+               <item row="7" column="2">
+                <widget class="QLabel" name="label_139">
                  <property name="text">
-                  <string>{frequency}</string>
-                 </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;123.925&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_125">
+               <item row="3" column="2">
+                <widget class="QLabel" name="label_148">
                  <property name="text">
-                  <string>{sectorOrLogin}</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Langen DKB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
-                 <property name="textInteractionFlags">
-                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </widget>
+               </item>
+               <item row="9" column="2">
+                <widget class="QLabel" name="label_159">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;twitch/username&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
@@ -4711,31 +4648,13 @@ info.</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="0" colspan="3">
-                <widget class="Line" name="line_6">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="2">
-                <widget class="QLabel" name="label_159">
+               <item row="9" column="0">
+                <widget class="QLabel" name="label_157">
                  <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;twitch/username&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>{livestream}</string>
                  </property>
-                </widget>
-               </item>
-               <item row="11" column="0">
-                <widget class="QLabel" name="label_180">
-                 <property name="text">
-                  <string>{livestream-}</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="2">
-                <widget class="QLabel" name="label_181">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;~&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                  </property>
                 </widget>
                </item>

--- a/src/mustache/Renderer.cpp
+++ b/src/mustache/Renderer.cpp
@@ -1,0 +1,67 @@
+#include "Renderer.h"
+
+#include "src/Airport.h"
+
+namespace MustacheQs {
+    Renderer* renderer = nullptr;
+    Renderer* Renderer::instance() {
+        if (renderer == nullptr) {
+            renderer = new Renderer();
+        }
+        return renderer;
+    }
+
+    QString Renderer::render(const QString &_template, QObject* _o) {
+        return instance()->m_render(_template, _o);
+    }
+
+    void Renderer::teardownContext(QObject* _o) {
+        instance()->m_teardownContext(_o);
+    }
+
+    Renderer::Renderer() {
+        m_renderer = Mustache::Renderer();
+        // we only use single braces
+        m_renderer.setTagMarkers("{", "}");
+    }
+
+    QString Renderer::m_render(const QString &_template, QObject* _o) {
+        return m_renderer.render(_template, m_context(_o));
+    }
+
+    void Renderer::m_teardownContext(QObject* _o) {
+        if (!m_contexts.contains(_o)) {
+            return;
+        }
+
+        auto context = m_contexts.take(_o);
+        delete context;
+    }
+
+    Mustache::Context* Renderer::m_context(QObject* _o) {
+        if (m_contexts.contains(_o)) {
+            return m_contexts.value(_o);
+        }
+
+        Mustache::Context* context;
+
+        ::Airport* a = qobject_cast<::Airport*>(_o);
+        if (a != 0) {
+            context = new MustacheQs::Airport::Context(a);
+        } else {
+            ::Controller* c = qobject_cast<::Controller*>(_o);
+            if (c != 0) {
+                context = new MustacheQs::Controller::Context(c);
+            } else {
+                ::Pilot* p = qobject_cast<::Pilot*>(_o);
+                if (p != 0) {
+                    context = new MustacheQs::Pilot::Context(p);
+                } else {
+                    context = new Mustache::QtVariantContext((QVariantHash()));
+                }
+            }
+        }
+        m_contexts.insert(_o, context);
+        return context;
+    }
+}

--- a/src/mustache/Renderer.h
+++ b/src/mustache/Renderer.h
@@ -1,0 +1,25 @@
+#ifndef MUSTACHEQS_RENDERER_H
+#define MUSTACHEQS_RENDERER_H
+
+#include "src/mustache/external/qt-mustache/mustache.h"
+
+namespace MustacheQs {
+    class Renderer {
+        public:
+            static Renderer* instance();
+            // when using this, call teardownContext() to release memory
+            static QString render(const QString& _template, QObject* _o);
+            static void teardownContext(QObject* _o);
+        private:
+            Renderer();
+
+            QString m_render(const QString& _template, QObject* _o);
+            void m_teardownContext(QObject* _o);
+            Mustache::Context* m_context(QObject* o);
+
+            Mustache::Renderer m_renderer;
+            QHash<QObject*, Mustache::Context*> m_contexts;
+    };
+}
+
+#endif

--- a/src/mustache/contexts/AirportContext.cpp
+++ b/src/mustache/contexts/AirportContext.cpp
@@ -1,0 +1,90 @@
+#include "AirportContext.h"
+
+#include "src/Airport.h"
+
+namespace MustacheQs::Airport {
+    PartialResolver* PartialResolver::inst = nullptr;
+    PartialResolver* PartialResolver::instance() {
+        if (inst == nullptr) {
+            inst = new PartialResolver();
+        }
+        return inst;
+    }
+
+    QString PartialResolver::getPartial(const QString &name) {
+        if (name == "traffic") {
+            return "{#arrs}{arrs}{/arrs}{^arrs}-{/arrs}/{#deps}{deps}{/deps}{^deps}-{/deps}";
+        }
+        if (name == "trafficArrows") {
+            return "{#arrs}{arrs}↘{/arrs}{#deps}↗{deps}{/deps}";
+        }
+        return QString("[> %1]").arg(name);
+    }
+
+    PartialResolver::PartialResolver() {}
+
+    Context::Context(const class Airport* a)
+        : Mustache::Context(PartialResolver::instance()), m_o(a) {}
+
+    Context::~Context() {}
+
+    QString Context::stringValue(const QString &key) const {
+        if (key == "code") {
+            return m_o->id;
+        }
+        if (key == "arrs") {
+            return QString::number(m_o->nMaybeFilteredArrivals);
+        }
+        if (key == "deps") {
+            return QString::number(m_o->nMaybeFilteredDepartures);
+        }
+        if (key == "allArrs") {
+            return QString::number(m_o->arrivals.count());
+        }
+        if (key == "allDeps") {
+            return QString::number(m_o->departures.count());
+        }
+        if (key == "controllers") {
+            return m_o->controllersString();
+        }
+        if (key == "atis") {
+            return m_o->atisCodeString();
+        }
+        if (key == "country") {
+            return m_o->countryCode;
+        }
+        if (key == "prettyName") {
+            return m_o->prettyName();
+        }
+        if (key == "name") {
+            return m_o->name;
+        }
+        if (key == "city") {
+            return m_o->city;
+        }
+        if (key == "frequencies") {
+            return m_o->frequencyString();
+        }
+        if (key == "pdc") {
+            return m_o->pdcString("");
+        }
+        if (key == "livestream") {
+            return m_o->livestreamString();
+        }
+
+        return QString("{%1}").arg(key);
+    }
+
+    bool Context::isFalse(const QString &key) const {
+        auto v = stringValue(key);
+        return v.isEmpty() || v == "0";
+    }
+
+    int Context::listCount(const QString&) const {
+        return 0;
+    }
+
+    void Context::push(const QString&, int) {}
+
+    void Context::pop() {}
+}

--- a/src/mustache/contexts/AirportContext.h
+++ b/src/mustache/contexts/AirportContext.h
@@ -1,0 +1,34 @@
+#ifndef MUSTACHEQS_AIRPORT_CONTEXT_H
+#define MUSTACHEQS_AIRPORT_CONTEXT_H
+
+#include "src/mustache/external/qt-mustache/mustache.h"
+
+class Airport;
+namespace MustacheQs::Airport {
+    class PartialResolver
+        : public Mustache::PartialResolver {
+        public:
+            static PartialResolver* instance();
+            virtual QString getPartial(const QString& name) override;
+        private:
+            PartialResolver();
+            static PartialResolver* inst;
+    };
+
+    class Context
+        : public Mustache::Context {
+        public:
+            Context(const class Airport*);
+            virtual ~Context();
+
+            virtual QString stringValue(const QString &key) const override;
+            virtual bool isFalse(const QString &key) const override;
+            virtual int listCount(const QString &key) const override;
+            virtual void push(const QString &key, int index) override;
+            virtual void pop() override;
+        private:
+            const class Airport* m_o;
+    };
+}
+
+#endif

--- a/src/mustache/contexts/ControllerContext.cpp
+++ b/src/mustache/contexts/ControllerContext.cpp
@@ -1,0 +1,73 @@
+#include "ControllerContext.h"
+
+#include "src/Controller.h"
+
+namespace MustacheQs::Controller {
+    PartialResolver* PartialResolver::inst = nullptr;
+    PartialResolver* PartialResolver::instance() {
+        if (inst == nullptr) {
+            inst = new PartialResolver();
+        }
+        return inst;
+    }
+
+    QString PartialResolver::getPartial(const QString &name) {
+        return QString("[> %1]").arg(name);
+    }
+
+    PartialResolver::PartialResolver() {}
+
+    Context::Context(const class Controller* a)
+        : Mustache::Context(PartialResolver::instance()), m_o(a) {}
+
+    Context::~Context() {}
+
+    QString Context::stringValue(const QString &key) const {
+        if (key == "sectorOrLogin") {
+            if (m_o->sector != 0) {
+                return m_o->controllerSectorName();
+            }
+
+            return m_o->callsign;
+        }
+        if (key == "sector") {
+            if (m_o->sector != 0) {
+                return m_o->sector->name;
+            }
+
+            return "";
+        }
+        if (key == "name") {
+            return m_o->aliasOrName();
+        }
+        if (key == "nameIfFriend") {
+            return m_o->isFriend()? m_o->aliasOrName(): "";
+        }
+        if (key == "rating") {
+            return m_o->rank();
+        }
+        if (key == "frequency") {
+            return m_o->frequency.length() > 1? m_o->frequency: "";
+        }
+        if (key == "cpdlc") {
+            return m_o->cpdlcString();
+        }
+        if (key == "livestream") {
+            return m_o->livestreamString();
+        }
+
+        return QString("{%1}").arg(key);
+    }
+
+    bool Context::isFalse(const QString &key) const {
+        return stringValue(key).isEmpty();
+    }
+
+    int Context::listCount(const QString&) const {
+        return 0;
+    }
+
+    void Context::push(const QString&, int) {}
+
+    void Context::pop() {}
+}

--- a/src/mustache/contexts/ControllerContext.h
+++ b/src/mustache/contexts/ControllerContext.h
@@ -1,0 +1,34 @@
+#ifndef MUSTACHEQS_CONTROLLER_CONTEXT_H
+#define MUSTACHEQS_CONTROLLER_CONTEXT_H
+
+#include "src/mustache/external/qt-mustache/mustache.h"
+
+class Controller;
+namespace MustacheQs::Controller {
+    class PartialResolver
+        : public Mustache::PartialResolver {
+        public:
+            static PartialResolver* instance();
+            virtual QString getPartial(const QString& name) override;
+        private:
+            PartialResolver();
+            static PartialResolver* inst;
+    };
+
+    class Context
+        : public Mustache::Context {
+        public:
+            Context(const class Controller*);
+            virtual ~Context();
+
+            virtual QString stringValue(const QString &key) const override;
+            virtual bool isFalse(const QString &key) const override;
+            virtual int listCount(const QString &key) const override;
+            virtual void push(const QString &key, int index) override;
+            virtual void pop() override;
+        private:
+            const class Controller* m_o;
+    };
+}
+
+#endif

--- a/src/mustache/contexts/PilotContext.cpp
+++ b/src/mustache/contexts/PilotContext.cpp
@@ -1,0 +1,88 @@
+#include "PilotContext.h"
+
+#include "src/Pilot.h"
+
+namespace MustacheQs::Pilot {
+    PartialResolver* PartialResolver::inst = nullptr;
+    PartialResolver* PartialResolver::instance() {
+        if (inst == nullptr) {
+            inst = new PartialResolver();
+        }
+        return inst;
+    }
+
+    QString PartialResolver::getPartial(const QString &name) {
+        return QString("[> %1]").arg(name);
+    }
+
+    PartialResolver::PartialResolver() {}
+
+    Context::Context(const class Pilot* a)
+        : Mustache::Context(PartialResolver::instance()), m_o(a) {}
+
+    Context::~Context() {}
+
+    QString Context::stringValue(const QString &key) const {
+        if (key == "login") {
+            return m_o->callsign;
+        }
+        if (key == "name") {
+            return m_o->aliasOrName();
+        }
+        if (key == "nameIfFriend") {
+            return m_o->isFriend()? m_o->aliasOrName(): "";
+        }
+        if (key == "rating") {
+            return m_o->rank();
+        }
+        if (key == "dep") {
+            return m_o->planDep;
+        }
+        if (key == "dest") {
+            return m_o->planDest;
+        }
+        if (key == "FL") {
+            return m_o->flOrEmpty();
+        }
+        if (key == "GS") {
+            auto _gs = m_o->groundspeed;
+            if (_gs == 0) {
+                return "";
+            }
+            return QString("N%1").arg(m_o->groundspeed);
+        }
+        if (key == "GS10") {
+            auto _gs = m_o->groundspeed;
+            if (_gs == 0) {
+                return "";
+            }
+            return QString("N%1").arg(round(m_o->groundspeed / 10.));
+        }
+        if (key == "rules") {
+            return m_o->planFlighttype;
+        }
+        if (key == "rulesIfNotIfr") {
+            return m_o->planFlighttype != "I"? m_o->planFlighttype: "";
+        }
+        if (key == "type") {
+            return m_o->aircraftType();
+        }
+        if (key == "livestream") {
+            return m_o->livestreamString();
+        }
+
+        return QString("{%1}").arg(key);
+    }
+
+    bool Context::isFalse(const QString &key) const {
+        return stringValue(key).isEmpty();
+    }
+
+    int Context::listCount(const QString&) const {
+        return 0;
+    }
+
+    void Context::push(const QString&, int) {}
+
+    void Context::pop() {}
+}

--- a/src/mustache/contexts/PilotContext.h
+++ b/src/mustache/contexts/PilotContext.h
@@ -1,0 +1,34 @@
+#ifndef MUSTACHEQS_PILOT_CONTEXT_H
+#define MUSTACHEQS_PILOT_CONTEXT_H
+
+#include "src/mustache/external/qt-mustache/mustache.h"
+
+class Pilot;
+namespace MustacheQs::Pilot {
+    class PartialResolver
+        : public Mustache::PartialResolver {
+        public:
+            static PartialResolver* instance();
+            virtual QString getPartial(const QString& name) override;
+        private:
+            PartialResolver();
+            static PartialResolver* inst;
+    };
+
+    class Context
+        : public Mustache::Context {
+        public:
+            Context(const class Pilot*);
+            virtual ~Context();
+
+            virtual QString stringValue(const QString &key) const override;
+            virtual bool isFalse(const QString &key) const override;
+            virtual int listCount(const QString &key) const override;
+            virtual void push(const QString &key, int index) override;
+            virtual void pop() override;
+        private:
+            const class Pilot* m_o;
+    };
+}
+
+#endif

--- a/src/mustache/external/qt-mustache/README.md
+++ b/src/mustache/external/qt-mustache/README.md
@@ -1,0 +1,70 @@
+# Qt Mustache
+
+qt-mustache is a simple library for rendering [Mustache templates](https://mustache.github.io/).
+
+### Example Usage
+
+```cpp
+#include "mustache.h"
+
+QVariantHash contact;
+contact["name"] = "John Smith";
+contact["email"] = "john.smith@gmail.com";
+
+QString contactTemplate = "<b>{{name}}</b> <a href=\"mailto:{{email}}\">{{email}}</a>";
+
+Mustache::Renderer renderer;
+Mustache::QtVariantContext context(contact);
+
+QTextStream output(stdout);
+output << renderer.render(contactTemplate, &context);
+```
+
+Outputs: `<b>John Smith</b> <a href="mailto:john.smith@gmail.com">john.smith@gmail.com</a>`
+
+For further examples, see the tests in `test_mustache.cpp`
+
+### Building
+ * To build the tests, run `qmake` followed by `make`
+ * To use qt-mustache in your project, just add the `mustache.h` and `mustache.cpp` files to your project.
+  
+### License
+ qt-mustache is licensed under the BSD license. 
+
+### Dependencies
+ qt-mustache depends on the QtCore library.  It is compatible with Qt 5 and Qt 6.
+ 
+## Usage
+
+### Syntax
+
+qt-mustache uses the standard Mustache syntax.  See the [Mustache manual](https://mustache.github.io/mustache.5.html) for details.
+
+### Data Sources
+
+qt-mustache expands Mustache tags using values from a `Mustache::Context`.  `Mustache::QtVariantContext` is a simple
+context implementation which wraps a `QVariantHash` or `QVariantMap`.  If you want to render a template using a custom data source,
+you can either create a `QVariantHash` which mirrors the data source or you can re-implement `Mustache::Context`.
+
+### Partials
+
+When a `{{>partial}}` Mustache tag is encountered, qt-mustache will attempt to load the partial using a `Mustache::PartialResolver`
+provided by the context.  `Mustache::PartialMap` is a simple resolver which takes a `QHash<QString,QString>` map of partial names
+to values and looks up partials in that map.  `Mustache::PartialFileLoader` is another simple resolver which
+fetches partials from `<partial name>.mustache` files in a specified directory.
+
+You can re-implement the `Mustache::PartialResolver` interface if you want to load partials from a custom source
+(eg. a database).
+
+### Error Handling
+
+If an error occurs when rendering a template, `Mustache::Renderer::errorPosition()` is set to non-negative value and
+template rendering stops.  If the error occurs whilst rendering a partial template, `errorPartial()` contains the name
+of the partial.
+
+### Lambdas
+
+The [Mustache manual](https://mustache.github.io/mustache.5.html) provides a mechanism to customize rendering of
+template sections by setting the value for a tag to a callable object (eg. a lambda in Ruby or Javascript),
+which takes the unrendered block of text for a template section and renders it itself.  qt-mustache supports
+this via the `Context::canEval()` and `Context::eval()` methods.

--- a/src/mustache/external/qt-mustache/mustache.cpp
+++ b/src/mustache/external/qt-mustache/mustache.cpp
@@ -1,0 +1,578 @@
+/*
+  Copyright 2012, Robert Knight
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+*/
+
+#include "mustache.h"
+
+#include <QtCore/QDebug>
+#include <QtCore/QFile>
+#include <QtCore/QStringList>
+#include <QtCore/QTextStream>
+
+using namespace Mustache;
+
+QString Mustache::renderTemplate(const QString& templateString, const QVariantHash& args)
+{
+	Mustache::QtVariantContext context(args);
+	Mustache::Renderer renderer;
+	return renderer.render(templateString, &context);
+}
+
+QString escapeHtml(const QString& input)
+{
+	QString escaped(input);
+	for (int i=0; i < escaped.length();) {
+		const char* replacement = 0;
+		ushort ch = escaped.at(i).unicode();
+		if (ch == '&') {
+			replacement = "&amp;";
+		} else if (ch == '<') {
+			replacement = "&lt;";
+		} else if (ch == '>') {
+			replacement = "&gt;";
+		} else if (ch == '"') {
+			replacement = "&quot;";
+		}
+		if (replacement) {
+			escaped.replace(i, 1, QLatin1String(replacement));
+			i += (int)strlen(replacement);
+		} else {
+			++i;
+		}
+	}
+	return escaped;
+}
+
+QString unescapeHtml(const QString& escaped)
+{
+	QString unescaped(escaped);
+	unescaped.replace(QLatin1String("&lt;"), QLatin1String("<"));
+	unescaped.replace(QLatin1String("&gt;"), QLatin1String(">"));
+	unescaped.replace(QLatin1String("&quot;"), QLatin1String("\""));
+	unescaped.replace(QLatin1String("&amp;"), QLatin1String("&"));
+	return unescaped;
+}
+
+Context::Context(PartialResolver* resolver)
+	: m_partialResolver(resolver)
+{}
+
+PartialResolver* Context::partialResolver() const
+{
+	return m_partialResolver;
+}
+
+QString Context::partialValue(const QString& key) const
+{
+	if (!m_partialResolver) {
+		return QString();
+	}
+	return m_partialResolver->getPartial(key);
+}
+
+bool Context::canEval(const QString&) const
+{
+	return false;
+}
+
+QString Context::eval(const QString& key, const QString& _template, Renderer* renderer)
+{
+	Q_UNUSED(key);
+	Q_UNUSED(_template);
+	Q_UNUSED(renderer);
+
+	return QString();
+}
+
+QtVariantContext::QtVariantContext(const QVariant& root, PartialResolver* resolver)
+	: Context(resolver)
+{
+	m_contextStack << root;
+}
+
+QVariant variantMapValue(const QVariant& value, const QString& key)
+{
+	if (value.userType() == QMetaType::QVariantMap) {
+		return value.toMap().value(key);
+	} else {
+		return value.toHash().value(key);
+	}
+}
+
+QVariant variantMapValueForKeyPath(const QVariant& value, const QStringList keyPath)
+{
+	if (keyPath.count() > 1) {
+		QVariant firstValue = variantMapValue(value, keyPath.first());
+		return firstValue.isNull() ? QVariant() : variantMapValueForKeyPath(firstValue, keyPath.mid(1));
+	} else if (!keyPath.isEmpty()) {
+		return variantMapValue(value, keyPath.first());
+	}
+	return QVariant();
+}
+
+QVariant QtVariantContext::value(const QString& key) const
+{
+	if (key == "." && !m_contextStack.isEmpty()) {
+		return m_contextStack.last();
+	}
+	QStringList keyPath = key.split(".");
+	for (int i = m_contextStack.count()-1; i >= 0; i--) {
+		QVariant value = variantMapValueForKeyPath(m_contextStack.at(i), keyPath);
+		if (!value.isNull()) {
+			return value;
+		}
+	}
+	return QVariant();
+}
+
+bool QtVariantContext::isFalse(const QString& key) const
+{
+	QVariant value = this->value(key);
+	switch (value.userType()) {
+	case QMetaType::Double:
+	case QMetaType::Float:
+		// QVariant::toBool() rounds floats to the nearest int and then compares
+		// against 0, which is not the falsiness behavior we want.
+		return value.toDouble() == 0.;
+	case QMetaType::QChar:
+	case QMetaType::Int:
+	case QMetaType::UInt:
+	case QMetaType::LongLong:
+	case QMetaType::ULongLong:
+	case QMetaType::Bool:
+		return !value.toBool();
+	case QMetaType::QVariantList:
+	case QMetaType::QStringList:
+		return value.toList().isEmpty();
+	case QMetaType::QVariantHash:
+		return value.toHash().isEmpty();
+	case QMetaType::QVariantMap:
+		return value.toMap().isEmpty();
+	default:
+		return value.toString().isEmpty();
+	}
+}
+
+QString QtVariantContext::stringValue(const QString& key) const
+{
+	return value(key).toString();
+}
+
+void QtVariantContext::push(const QString& key, int index)
+{
+	QVariant mapItem = value(key);
+	if (index == -1) {
+		m_contextStack << mapItem;
+	} else {
+		QVariantList list = mapItem.toList();
+		m_contextStack << list.value(index, QVariant());
+	}
+}
+
+void QtVariantContext::pop()
+{
+	m_contextStack.pop();
+}
+
+int QtVariantContext::listCount(const QString& key) const
+{
+	const QVariant& item = value(key);
+	if (item.canConvert<QVariantList>() && item.userType() != QMetaType::QString) {
+		return item.toList().count();
+	}
+	return 0;
+}
+
+bool QtVariantContext::canEval(const QString& key) const
+{
+	return value(key).canConvert<fn_t>();
+}
+
+QString QtVariantContext::eval(const QString& key, const QString& _template, Renderer* renderer)
+{
+	QVariant fn = value(key);
+	if (fn.isNull()) {
+		return QString();
+	}
+	return fn.value<fn_t>()(_template, renderer, this);
+}
+
+PartialMap::PartialMap(const QHash<QString, QString>& partials)
+	: m_partials(partials)
+{}
+
+QString PartialMap::getPartial(const QString& name)
+{
+	return m_partials.value(name);
+}
+
+PartialFileLoader::PartialFileLoader(const QString& basePath)
+	: m_basePath(basePath)
+{}
+
+QString PartialFileLoader::getPartial(const QString& name)
+{
+	if (!m_cache.contains(name)) {
+		QString path = m_basePath + '/' + name + ".mustache";
+		QFile file(path);
+		if (file.open(QIODevice::ReadOnly)) {
+			QTextStream stream(&file);
+			m_cache.insert(name, stream.readAll());
+		}
+	}
+	return m_cache.value(name);
+}
+
+Renderer::Renderer()
+	: m_errorPos(-1)
+	, m_defaultTagStartMarker("{{")
+	, m_defaultTagEndMarker("}}")
+{
+}
+
+QString Renderer::error() const
+{
+	return m_error;
+}
+
+int Renderer::errorPos() const
+{
+	return m_errorPos;
+}
+
+QString Renderer::errorPartial() const
+{
+	return m_errorPartial;
+}
+
+QString Renderer::render(const QString& _template, Context* context)
+{
+	m_error.clear();
+	m_errorPos = -1;
+	m_errorPartial.clear();
+
+	m_tagStartMarker = m_defaultTagStartMarker;
+	m_tagEndMarker = m_defaultTagEndMarker;
+
+	return render(_template, 0, _template.length(), context);
+}
+
+QString Renderer::render(const QString& _template, int startPos, int endPos, Context* context)
+{
+	QString output;
+	int lastTagEnd = startPos;
+
+	while (m_errorPos == -1) {
+		Tag tag = findTag(_template, lastTagEnd, endPos);
+		if (tag.type == Tag::Null) {
+			output += QStringView(_template).mid(lastTagEnd, endPos - lastTagEnd);
+			break;
+		}
+		output += QStringView(_template).mid(lastTagEnd, tag.start - lastTagEnd);
+		switch (tag.type) {
+		case Tag::Value:
+		{
+			QString value = context->stringValue(tag.key);
+			if (tag.escapeMode == Tag::Escape) {
+				value = escapeHtml(value);
+			} else if (tag.escapeMode == Tag::Unescape) {
+				value = unescapeHtml(value);
+			}
+			output += value;
+			lastTagEnd = tag.end;
+		}
+		break;
+		case Tag::SectionStart:
+		{
+			Tag endTag = findEndTag(_template, tag, endPos);
+			if (endTag.type == Tag::Null) {
+				if (m_errorPos == -1) {
+					setError("No matching end tag found for section", tag.start);
+				}
+			} else {
+				int listCount = context->listCount(tag.key);
+				if (listCount > 0) {
+					for (int i=0; i < listCount; i++) {
+						context->push(tag.key, i);
+						output += render(_template, tag.end, endTag.start, context);
+						context->pop();
+					}
+				} else if (context->canEval(tag.key)) {
+					output += context->eval(tag.key, _template.mid(tag.end, endTag.start - tag.end), this);
+				} else if (!context->isFalse(tag.key)) {
+					context->push(tag.key);
+					output += render(_template, tag.end, endTag.start, context);
+					context->pop();
+				}
+				lastTagEnd = endTag.end;
+			}
+		}
+		break;
+		case Tag::InvertedSectionStart:
+		{
+			Tag endTag = findEndTag(_template, tag, endPos);
+			if (endTag.type == Tag::Null) {
+				if (m_errorPos == -1) {
+					setError("No matching end tag found for inverted section", tag.start);
+				}
+			} else {
+				if (context->isFalse(tag.key)) {
+					output += render(_template, tag.end, endTag.start, context);
+				}
+				lastTagEnd = endTag.end;
+			}
+		}
+		break;
+		case Tag::SectionEnd:
+			setError("Unexpected end tag", tag.start);
+			lastTagEnd = tag.end;
+			break;
+		case Tag::Partial:
+		{
+			QString tagStartMarker = m_tagStartMarker;
+			QString tagEndMarker = m_tagEndMarker;
+
+			m_tagStartMarker = m_defaultTagStartMarker;
+			m_tagEndMarker = m_defaultTagEndMarker;
+
+			m_partialStack.push(tag.key);
+
+			QString partialContent = context->partialValue(tag.key);
+
+			// If there is a need to add a special indentation to the partial
+			if (tag.indentation > 0) {
+				output += QString(" ").repeated(tag.indentation);
+				// Indenting the output to keep the parent indentation.
+				int posOfLF = partialContent.indexOf("\n", 0);
+				while (posOfLF > 0 && posOfLF < (partialContent.length() - 1)) { // .length() - 1 because we dont want indentation AFTER the last character if it's a LF
+					partialContent = partialContent.insert(posOfLF + 1, QString(" ").repeated(tag.indentation));
+					posOfLF = partialContent.indexOf("\n", posOfLF + 1);
+				}
+			}
+
+			QString partialRendered = render(partialContent, 0, partialContent.length(), context);
+
+			output += partialRendered;
+
+			lastTagEnd = tag.end;
+
+			m_partialStack.pop();
+
+			m_tagStartMarker = tagStartMarker;
+			m_tagEndMarker = tagEndMarker;
+		}
+		break;
+		case Tag::SetDelimiter:
+			lastTagEnd = tag.end;
+			break;
+		case Tag::Comment:
+			lastTagEnd = tag.end;
+			break;
+		case Tag::Null:
+			break;
+		}
+	}
+
+	return output;
+}
+
+void Renderer::setError(const QString& error, int pos)
+{
+	Q_ASSERT(!error.isEmpty());
+	Q_ASSERT(pos >= 0);
+
+	m_error = error;
+	m_errorPos = pos;
+
+	if (!m_partialStack.isEmpty())
+	{
+		m_errorPartial = m_partialStack.top();
+	}
+}
+
+Tag Renderer::findTag(const QString& content, int pos, int endPos)
+{
+	int tagStartPos = content.indexOf(m_tagStartMarker, pos);
+	if (tagStartPos == -1 || tagStartPos >= endPos) {
+		return Tag();
+	}
+
+	int tagEndPos = content.indexOf(m_tagEndMarker, tagStartPos + m_tagStartMarker.length());
+	if (tagEndPos == -1) {
+		return Tag();
+	}
+	tagEndPos += m_tagEndMarker.length();
+
+	Tag tag;
+	tag.type = Tag::Value;
+	tag.start = tagStartPos;
+	tag.end = tagEndPos;
+
+	pos = tagStartPos + m_tagStartMarker.length();
+	endPos = tagEndPos - m_tagEndMarker.length();
+
+	QChar typeChar = content.at(pos);
+
+	if (typeChar == '#') {
+		tag.type = Tag::SectionStart;
+		tag.key = readTagName(content, pos+1, endPos);
+	} else if (typeChar == '^') {
+		tag.type = Tag::InvertedSectionStart;
+		tag.key = readTagName(content, pos+1, endPos);
+	} else if (typeChar == '/') {
+		tag.type = Tag::SectionEnd;
+		tag.key = readTagName(content, pos+1, endPos);
+	} else if (typeChar == '!') {
+		tag.type = Tag::Comment;
+	} else if (typeChar == '>') {
+		tag.type = Tag::Partial;
+		tag.key = readTagName(content, pos+1, endPos);
+	} else if (typeChar == '=') {
+		tag.type = Tag::SetDelimiter;
+		readSetDelimiter(content, pos+1, tagEndPos - m_tagEndMarker.length());
+	} else {
+		if (typeChar == '&') {
+			tag.escapeMode = Tag::Unescape;
+			++pos;
+		} else if (typeChar == '{') {
+			tag.escapeMode = Tag::Raw;
+			++pos;
+			int endTache = content.indexOf('}', pos);
+			if (endTache == tag.end - m_tagEndMarker.length()) {
+				++tag.end;
+			} else {
+				endPos = endTache;
+			}
+		}
+		tag.type = Tag::Value;
+		tag.key = readTagName(content, pos, endPos);
+	}
+
+	if (tag.type != Tag::Value) {
+		expandTag(tag, content);
+	}
+
+	return tag;
+}
+
+QString Renderer::readTagName(const QString& content, int pos, int endPos)
+{
+	QString name;
+	name.reserve(endPos - pos);
+	while (content.at(pos).isSpace()) {
+		++pos;
+	}
+	while (!content.at(pos).isSpace() && pos < endPos) {
+		name += content.at(pos);
+		++pos;
+	}
+	return name;
+}
+
+void Renderer::readSetDelimiter(const QString& content, int pos, int endPos)
+{
+	QString startMarker;
+	QString endMarker;
+
+	while (content.at(pos).isSpace() && pos < endPos) {
+		++pos;
+	}
+
+	while (!content.at(pos).isSpace() && pos < endPos) {
+		if (content.at(pos) == '=') {
+			setError("Custom delimiters may not contain '='.", pos);
+			return;
+		}
+		startMarker += content.at(pos);
+		++pos;
+	}
+
+	while (content.at(pos).isSpace() && pos < endPos) {
+		++pos;
+	}
+
+	while (!content.at(pos).isSpace() && pos < endPos - 1) {
+		if (content.at(pos) == '=') {
+			setError("Custom delimiters may not contain '='.", pos);
+			return;
+		}
+		endMarker += content.at(pos);
+		++pos;
+	}
+
+	m_tagStartMarker = startMarker;
+	m_tagEndMarker = endMarker;
+}
+
+Tag Renderer::findEndTag(const QString& content, const Tag& startTag, int endPos)
+{
+	int tagDepth = 1;
+	int pos = startTag.end;
+
+	while (true) {
+		Tag nextTag = findTag(content, pos, endPos);
+		if (nextTag.type == Tag::Null) {
+			return nextTag;
+		} else if (nextTag.type == Tag::SectionStart || nextTag.type == Tag::InvertedSectionStart) {
+			++tagDepth;
+		} else if (nextTag.type == Tag::SectionEnd) {
+			--tagDepth;
+			if (tagDepth == 0) {
+				if (nextTag.key != startTag.key) {
+					setError("Tag start/end key mismatch", nextTag.start);
+					return Tag();
+				}
+				return nextTag;
+			}
+		}
+		pos = nextTag.end;
+	}
+
+	return Tag();
+}
+
+void Renderer::setTagMarkers(const QString& startMarker, const QString& endMarker)
+{
+	m_defaultTagStartMarker = startMarker;
+	m_defaultTagEndMarker = endMarker;
+}
+
+void Renderer::expandTag(Tag& tag, const QString& content)
+{
+	int start = tag.start;
+	int end = tag.end;
+	int indentation = 0;
+
+	// Move start to beginning of line.
+	while (start > 0 && content.at(start - 1) != QLatin1Char('\n')) {
+		--start;
+		if (!content.at(start).isSpace()) {
+			return; // Not standalone.
+		} else if (content.at(start).category() == QChar::Separator_Space) {
+			// If its an actual "white space" and not a new line, it counts toward indentation.
+			++indentation;
+		}
+	}
+
+	// Move end to one past end of line.
+	while (end <= content.size() && content.at(end - 1) != QLatin1Char('\n')) {
+		if (end < content.size() && !content.at(end).isSpace()) {
+			return; // Not standalone.
+		}
+		++end;
+	}
+
+	tag.start = start;
+	tag.end = end;
+	tag.indentation = indentation;
+}

--- a/src/mustache/external/qt-mustache/mustache.h
+++ b/src/mustache/external/qt-mustache/mustache.h
@@ -1,0 +1,279 @@
+/*
+  Copyright 2012, Robert Knight
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+*/
+
+#pragma once
+
+#include <QtCore/QStack>
+#include <QtCore/QString>
+#include <QtCore/QVariant>
+
+#if __cplusplus >= 201103L
+#include <functional> /* for std::function */
+#endif
+
+namespace Mustache
+{
+
+class PartialResolver;
+class Renderer;
+
+/** Context is an interface that Mustache::Renderer::render() uses to
+  * fetch substitutions for template tags.
+  */
+class Context
+{
+public:
+	/** Create a context.  @p resolver is used to fetch the expansions for any {{>partial}} tags
+	  * which appear in a template.
+	  */
+	explicit Context(PartialResolver* resolver = 0);
+	virtual ~Context() {}
+
+	/** Returns a string representation of the value for @p key in the current context.
+	  * This is used to replace a Mustache value tag.
+	  */
+	virtual QString stringValue(const QString& key) const = 0;
+
+	/** Returns true if the value for @p key is 'false' or an empty list.
+	  * 'False' values typically include empty strings, the boolean value false etc.
+	  *
+	  * When processing a section Mustache tag, the section is not rendered if the key
+	  * is false, or for an inverted section tag, the section is only rendered if the key
+	  * is false.
+	  */
+	virtual bool isFalse(const QString& key) const = 0;
+
+	/** Returns the number of items in the list value for @p key or 0 if
+	  * the value for @p key is not a list.
+	  */
+	virtual int listCount(const QString& key) const = 0;
+
+	/** Set the current context to the value for @p key.
+	  * If index is >= 0, set the current context to the @p index'th value
+	  * in the list value for @p key.
+	  */
+	virtual void push(const QString& key, int index = -1) = 0;
+
+	/** Exit the current context. */
+	virtual void pop() = 0;
+
+	/** Returns the partial template for a given @p key. */
+	QString partialValue(const QString& key) const;
+
+	/** Returns the partial resolver passed to the constructor. */
+	PartialResolver* partialResolver() const;
+
+	/** Returns true if eval() should be used to render section tags using @p key.
+	 * If canEval() returns true for a key, the renderer will pass the literal, unrendered
+	 * block of text for the section to eval() and replace the section with the result.
+	 *
+	 * canEval() and eval() are equivalents for callable objects (eg. lambdas) in other
+	 * Mustache implementations.
+	 *
+	 * The default implementation always returns false.
+	 */
+	virtual bool canEval(const QString& key) const;
+
+	/** Callback used to render a template section with the given @p key.
+	 * @p renderer will substitute the original section tag with the result of eval().
+	 *
+	 * The default implementation returns an empty string.
+	 */
+	virtual QString eval(const QString& key, const QString& _template, Renderer* renderer);
+
+private:
+	PartialResolver* m_partialResolver;
+};
+
+/** A context implementation which wraps a QVariantHash or QVariantMap. */
+class QtVariantContext : public Context
+{
+public:
+	/** Construct a QtVariantContext which wraps a dictionary in a QVariantHash
+	 * or a QVariantMap.
+	 */
+#if __cplusplus >= 201103L
+	typedef std::function<QString(const QString&, Mustache::Renderer*, Mustache::Context*)> fn_t;
+#else
+	typedef QString (*fn_t)(const QString&, Mustache::Renderer*, Mustache::Context*);
+#endif
+	explicit QtVariantContext(const QVariant& root, PartialResolver* resolver = 0);
+
+	virtual QString stringValue(const QString& key) const;
+	virtual bool isFalse(const QString& key) const;
+	virtual int listCount(const QString& key) const;
+	virtual void push(const QString& key, int index = -1);
+	virtual void pop();
+	virtual bool canEval(const QString& key) const;
+	virtual QString eval(const QString& key, const QString& _template, Mustache::Renderer* renderer);
+
+private:
+	QVariant value(const QString& key) const;
+
+	QStack<QVariant> m_contextStack;
+};
+
+/** Interface for fetching template partials. */
+class PartialResolver
+{
+public:
+	virtual ~PartialResolver() {}
+
+	/** Returns the partial template with a given @p name. */
+	virtual QString getPartial(const QString& name) = 0;
+};
+
+/** A simple partial fetcher which returns templates from a map of (partial name -> template)
+  */
+class PartialMap : public PartialResolver
+{
+public:
+	explicit PartialMap(const QHash<QString,QString>& partials);
+
+	virtual QString getPartial(const QString& name);
+
+private:
+	QHash<QString, QString> m_partials;
+};
+
+/** A partial fetcher when loads templates from '<name>.mustache' files
+ * in a given directory.
+ *
+ * Once a partial has been loaded, it is cached for future use.
+ */
+class PartialFileLoader : public PartialResolver
+{
+public:
+	explicit PartialFileLoader(const QString& basePath);
+
+	virtual QString getPartial(const QString& name);
+
+private:
+	QString m_basePath;
+	QHash<QString, QString> m_cache;
+};
+
+/** Holds properties of a tag in a mustache template. */
+struct Tag
+{
+	enum Type
+	{
+		Null,
+		Value, /// A {{key}} or {{{key}}} tag
+		SectionStart, /// A {{#section}} tag
+		InvertedSectionStart, /// An {{^inverted-section}} tag
+		SectionEnd, /// A {{/section}} tag
+		Partial, /// A {{^partial}} tag
+		Comment, /// A {{! comment }} tag
+		SetDelimiter /// A {{=<% %>=}} tag
+	};
+
+	enum EscapeMode
+	{
+		Escape,
+		Unescape,
+		Raw
+	};
+
+	Tag()
+		: type(Null)
+		, start(0)
+        , end(0)
+        /* QuteScoop-Jonas: we don't want to escape for HTML output: */
+        , escapeMode(Raw)
+		, indentation(0)
+	{}
+
+	Type type;
+	QString key;
+	int start;
+	int end;
+	EscapeMode escapeMode;
+	int indentation;
+};
+
+/** Renders Mustache templates, replacing mustache tags with
+  * values from a provided context.
+  */
+class Renderer
+{
+public:
+	Renderer();
+
+	/** Render a Mustache template, using @p context to fetch
+	  * the values used to replace Mustache tags.
+	  */
+	QString render(const QString& _template, Context* context);
+
+	/** Returns a message describing the last error encountered by the previous
+	  * render() call.
+	  */
+	QString error() const;
+
+	/** Returns the position in the template where the last error occurred
+	  * when rendering the template or -1 if no error occurred.
+	  *
+	  * If the error occurred in a partial template, the returned position is the offset
+	  * in the partial template.
+	  */
+	int errorPos() const;
+
+	/** Returns the name of the partial where the error occurred, or an empty string
+	 * if the error occurred in the main template.
+	 */
+	QString errorPartial() const;
+
+	/** Sets the default tag start and end markers.
+	  * This can be overridden within a template.
+	  */
+	void setTagMarkers(const QString& startMarker, const QString& endMarker);
+
+private:
+	QString render(const QString& _template, int startPos, int endPos, Context* context);
+
+	Tag findTag(const QString& content, int pos, int endPos);
+	Tag findEndTag(const QString& content, const Tag& startTag, int endPos);
+	void setError(const QString& error, int pos);
+
+	void readSetDelimiter(const QString& content, int pos, int endPos);
+	static QString readTagName(const QString& content, int pos, int endPos);
+
+	/** Expands @p tag to fill the line, but only if it is standalone.
+	 *
+	 * The start position is moved to the beginning of the line. The end position is
+	 * moved to one past the end of the line. If @p tag is not standalone, it is
+	 * left unmodified.
+	 *
+	 * A tag is standalone if it is the only non-whitespace token on the the line.
+	 */
+	static void expandTag(Tag& tag, const QString& content);
+
+	QStack<QString> m_partialStack;
+	QString m_error;
+	int m_errorPos;
+	QString m_errorPartial;
+
+	QString m_tagStartMarker;
+	QString m_tagEndMarker;
+
+	QString m_defaultTagStartMarker;
+	QString m_defaultTagEndMarker;
+};
+
+/** A convenience function which renders a template using the given data. */
+QString renderTemplate(const QString& templateString, const QVariantHash& args);
+
+}
+
+Q_DECLARE_METATYPE(Mustache::QtVariantContext::fn_t)


### PR DESCRIPTION
This implements https://mustache.github.io/mustache.5.html . See the little manual for its features. It can be used in the labels of pilots, sectors and airports for now.

Default label contents have been adapted and are now using some Unicode symbols.

Fixes: #310

Thanks to all contributors of the library
[qt-mustache](https://github.com/robertknight/qt-mustache).