### PR TITLE
[FEATURE] mark filtered arrivals/departures in airport details dialog

### DIFF
--- a/src/Airac.cpp
+++ b/src/Airac.cpp
@@ -311,13 +311,13 @@ Waypoint* Airac::waypointNearby(const QString& input, double lat, double lon, do
     if (NavData::instance()->airports.contains(input)) { // trying aerodromes
         double d = NavData::distance(
             lat, lon,
-            NavData::instance()->airports[input]->lat,
-            NavData::instance()->airports[input]->lon
+            NavData::instance()->airports.value(input)->lat,
+            NavData::instance()->airports.value(input)->lon
         );
         if ((d < minDist) && (d < maxDist)) {
             result = new Waypoint(
-                input, NavData::instance()->airports[input]->lat,
-                NavData::instance()->airports[input]->lon
+                input, NavData::instance()->airports.value(input)->lat,
+                NavData::instance()->airports.value(input)->lon
             );
             minDist = d;
         }

--- a/src/Metar.cpp
+++ b/src/Metar.cpp
@@ -338,7 +338,7 @@ QString Metar::humanHtml() const {
     }
 
     // LOWW 012020Z 35006KT 320V040 9999 -RA FEW060 SCT070 BKN080 08/05 Q1014 NOSIG
-    Airport* a = NavData::instance()->airports[tokens.first()];
+    Airport* a = NavData::instance()->airports.value(tokens.first());
     if (a == 0) {
         result = tokens.first();
     } else {

--- a/src/NavData.cpp
+++ b/src/NavData.cpp
@@ -62,7 +62,7 @@ void NavData::loadAirports(const QString& filename) {
             continue;
         }
 
-        airports[airport->id] = airport;
+        airports.insert(airport->id, airport);
     }
 
     if (countMissingCountry != 0) {
@@ -224,7 +224,7 @@ void NavData::updateData(const WhazzupData& whazzupData) {
         if (p == 0) {
             continue;
         }
-        Airport* dep = airports.value(p->planDep, 0);
+        Airport* dep = p->depAirport();
         if (dep != 0) {
             dep->addDeparture(p);
             newActiveAirportsSet.insert(dep);
@@ -242,20 +242,21 @@ void NavData::updateData(const WhazzupData& whazzupData) {
                 newActiveAirportsSet.insert(a);
             }
         }
-        Airport* dest = airports.value(p->planDest, 0);
+        Airport* dest = p->destAirport();
         if (dest != 0) {
             dest->addArrival(p);
             newActiveAirportsSet.insert(dest);
             if (
-                !Settings::filterTraffic()
-                || (
-                    (p->distanceToDestination() < Settings::filterDistance())
-                    || (p->eet().hour() + p->eet().minute() / 60. < Settings::filterArriving())
+                (
+                    !Settings::filterTraffic()
+                    || (
+                        (p->distanceToDestination() < Settings::filterDistance())
+                        || (p->eet().hour() + p->eet().minute() / 60. < Settings::filterArriving())
+                    )
                 )
+                && (p->flightStatus() != Pilot::FlightStatus::BLOCKED && p->flightStatus() != Pilot::FlightStatus::GROUND_ARR)
             ) {
-                if (p->flightStatus() != Pilot::FlightStatus::BLOCKED && p->flightStatus() != Pilot::FlightStatus::GROUND_ARR) {
-                    dest->nMaybeFilteredArrivals++;
-                }
+                dest->nMaybeFilteredArrivals++;
             }
         }
     }

--- a/src/Pilot.cpp
+++ b/src/Pilot.cpp
@@ -357,6 +357,14 @@ double Pilot::distanceToDestination() const {
         return 0;
     }
 
+    if (flightStatus() == Pilot::PREFILED) {
+        Airport* dep = depAirport();
+        if (dep == 0) {
+            return 0;
+        }
+        return NavData::distance(dep->lat, dep->lon, dest->lat, dest->lon);
+    }
+
     return NavData::distance(lat, lon, dest->lat, dest->lon);
 }
 

--- a/src/QuteScoop.cpp
+++ b/src/QuteScoop.cpp
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
         route.prepend(depString);
         QTextStream(stdout) << "\n# Flightplan route:\n" << route.join(" ") << Qt::endl;
 
-        const auto dep = NavData::instance()->airports[depString];
+        const auto dep = NavData::instance()->airports.value(depString, 0);
         if (dep == 0) {
             QTextStream(stdout) << "ERROR: departure aerodrome not found in database" << Qt::endl;
             return 1;

--- a/src/Route.cpp
+++ b/src/Route.cpp
@@ -8,17 +8,9 @@ Route::Route() {}
 Route::~Route() {}
 
 void Route::calculateWaypointsAndDistance() {
-    Airport* depAirport;
-    if (NavData::instance()->airports.contains(dep)) {
-        depAirport = NavData::instance()->airports[dep];
-    } else {
-        return;
-    }
-
-    Airport* destAirport;
-    if (NavData::instance()->airports.contains(dest)) {
-        destAirport = NavData::instance()->airports[dest];
-    } else {
+    Airport* depAirport = NavData::instance()->airports.value(dep, 0);
+    Airport* destAirport = NavData::instance()->airports.value(dest, 0);
+    if (depAirport == 0 || destAirport == 0) {
         return;
     }
 

--- a/src/WhazzupData.cpp
+++ b/src/WhazzupData.cpp
@@ -88,6 +88,12 @@ WhazzupData::WhazzupData(QByteArray* bytes, WhazzupType type)
             for (int i = 0; i < prefilesArray.size(); ++i) {
                 QJsonObject prefileObject = prefilesArray[i].toObject();
                 Pilot* p = new Pilot(prefileObject, this);
+                // currently not possible. Logic relies on lat=0, lon=0 for prefiles
+//                auto* a = p->depAirport();
+//                if (a != 0) {
+//                    p->lat = a->lat;
+//                    p->lon = a->lon;
+//                }
                 bookedPilots[p->callsign] = p;
             }
         }

--- a/src/models/AirportDetailsDeparturesModel.cpp
+++ b/src/models/AirportDetailsDeparturesModel.cpp
@@ -1,6 +1,7 @@
 #include "AirportDetailsDeparturesModel.h"
 
-#include "../Airport.h"
+#include "src/Airport.h"
+#include "src/Settings.h"
 
 #include <QFont>
 
@@ -41,6 +42,19 @@ QVariant AirportDetailsDeparturesModel::data(const QModelIndex &index, int role)
     }
 
     Pilot* p = _pilots[index.row()];
+
+    if (index.column() == 6) {
+        const bool isFilteredDep = Settings::filterTraffic()
+            && p->distanceFromDeparture() < Settings::filterDistance();
+
+        if (isFilteredDep) {
+            if (role == Qt::ForegroundRole) {
+                return QGuiApplication::palette().window();
+            } else if (role == Qt::BackgroundRole) {
+                return QGuiApplication::palette().text();
+            }
+        }
+    }
 
     if (role == Qt::FontRole) {
         QFont result;


### PR DESCRIPTION
This visually highlights arrivals/departures that match the arrivals/departure filter.

It also fixes sorting in the "TTG" (aka "ETA") column for very long (> 10 hours) flights.

It also locates prefiled flights at the departure airport, giving us a "correct" distance to destination although the user has not yet connected.