### PR TITLE
[TASK] use SOBT/STA terminology

### DIFF
--- a/src/Pilot.cpp
+++ b/src/Pilot.cpp
@@ -379,7 +379,7 @@ int Pilot::planTasInt() const { // defuck flightplanned TAS
     return planTAS.toInt();
 }
 
-QDateTime Pilot::etd() const { // Estimated Time of Departure
+QDateTime Pilot::etd() const { // Estimated Time of Departure - but according to the web form SOBT
     QString planDeptimeFixed = planDeptime;
 
     if (planDeptime.length() == 3) {

--- a/src/dialogs/PilotDetails.ui
+++ b/src/dialogs/PilotDetails.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../Resources.qrc">
     <normaloff>:/icons/qutescoop.png</normaloff>:/icons/qutescoop.png</iconset>
   </property>
   <property name="sizeGripEnabled">
@@ -274,183 +274,11 @@ delay: difference between planned and calculated ETA</string>
      <property name="title">
       <string>Flightplan (IFR)</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,0">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="font">
-         <font>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="toolTip">
-         <string>departure aerodrome / &lt;b&gt;p&lt;/b&gt;lanned &lt;b&gt;t&lt;/b&gt;ime of &lt;b&gt;d&lt;/b&gt;eparture</string>
-        </property>
-        <property name="text">
-         <string>dep/PTD</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="buttonFrom">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="toolTip">
-         <string>open departure aerodrome details dialog</string>
-        </property>
-        <property name="text">
-         <string>LOWW (Vienna, AT)</string>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="lblPlanEtd">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="toolTip">
-         <string>ETD: &lt;b&gt;e&lt;/b&gt;stimated &lt;b&gt;t&lt;/b&gt;ime of &lt;b&gt;d&lt;/b&gt;eparture</string>
-        </property>
-        <property name="text">
-         <string>1035</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>z</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="font">
-         <font>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="toolTip">
-         <string>destination / &lt;b&gt;p&lt;/b&gt;lanned &lt;b&gt;t&lt;/b&gt;ime of &lt;b&gt;a&lt;/b&gt;rrival</string>
-        </property>
-        <property name="text">
-         <string>dest/PTA</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="buttonDest">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="toolTip">
-         <string>open destination aerodrome details dialog</string>
-        </property>
-        <property name="text">
-         <string>LOWI (Innsbruck, AT)</string>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="lblPlanEta">
-        <property name="font">
-         <font>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="toolTip">
-         <string>ETA: &lt;b&gt;e&lt;/b&gt;stimated &lt;b&gt;t&lt;/b&gt;ime of &lt;b&gt;a&lt;/b&gt;rrival</string>
-        </property>
-        <property name="text">
-         <string>1125</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>z</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;alternate aerodrome / fuel endurance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>altern/fuel</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QPushButton" name="buttonAlt">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>open alternate aerodrome details dialog</string>
-        </property>
-        <property name="text">
-         <string>LOWS (Salzburg, AT)</string>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
+     <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,0,0,0">
+      <item row="2" column="4">
        <widget class="QLabel" name="lblFuel">
         <property name="toolTip">
-         <string>fuel on board</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;fuel endurance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>2:00</string>
@@ -460,109 +288,17 @@ delay: difference between planned and calculated ETA</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="3">
-       <widget class="QLabel" name="label_11">
-        <property name="text">
-         <string>hrs</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="font">
-         <font>
-          <bold>true</bold>
-         </font>
-        </property>
+      <item row="1" column="5">
+       <widget class="QLabel" name="label_7">
         <property name="toolTip">
-         <string>filed &lt;b&gt;t&lt;/b&gt;rue &lt;b&gt;a&lt;/b&gt;ir&lt;b&gt;s&lt;/b&gt;peed / cruise level / &lt;b&gt;p&lt;/b&gt;lanned &lt;b&gt;t&lt;/b&gt;ime &lt;b&gt;e&lt;/b&gt;nroute</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;S&lt;/span&gt;cheduled &lt;span style=&quot; font-weight:700;&quot;&gt;t&lt;/span&gt;ime &lt;span style=&quot; font-weight:700;&quot;&gt;o&lt;/span&gt;f &lt;span style=&quot; font-weight:700;&quot;&gt;a&lt;/span&gt;rrival&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
-         <string>TAS/FL/PTE</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <string>z</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="lblPlanTas">
-          <property name="font">
-           <font>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>ICAO flightplan format for true airspeed (TAS)</string>
-          </property>
-          <property name="text">
-           <string>N420</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="lblPlanFl">
-          <property name="font">
-           <font>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>ICAO flightplan format for flight level</string>
-          </property>
-          <property name="text">
-           <string>F340</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="3" column="2">
-       <widget class="QLabel" name="lblPlanEte">
-        <property name="font">
-         <font>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="toolTip">
-         <string>ETE: &lt;b&gt;e&lt;/b&gt;stimated &lt;b&gt;t&lt;/b&gt;ime &lt;b&gt;e&lt;/b&gt;nroute</string>
-        </property>
-        <property name="text">
-         <string>0:50</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="3">
-       <widget class="QLabel" name="label_8">
-        <property name="text">
-         <string>hrs</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="font">
-         <font>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>route</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" colspan="3">
+      <item row="4" column="1" colspan="5">
        <widget class="QLabel" name="lblRoute">
         <property name="mouseTracking">
          <bool>true</bool>
@@ -575,6 +311,58 @@ delay: difference between planned and calculated ETA</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;alternate aerodrome / fuel endurance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>altern</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;destination aerodrome&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>dest</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="5">
+       <widget class="QLabel" name="lblPlotStatus">
+        <property name="font">
+         <font>
+          <italic>true</italic>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>Extracted from the route with help of the navigation database</string>
+        </property>
+        <property name="text">
+         <string>waypoints (calculated): ...</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -615,24 +403,42 @@ route</string>
         </item>
        </layout>
       </item>
-      <item row="5" column="1" colspan="3">
-       <widget class="QLabel" name="lblPlotStatus">
-        <property name="font">
-         <font>
-          <italic>true</italic>
-         </font>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="buttonAlt">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>Extracted from the route with help of the navigation database</string>
+         <string>open alternate aerodrome details dialog</string>
         </property>
         <property name="text">
-         <string>waypoints (calculated): ...</string>
+         <string>LOWS (Salzburg, AT)</string>
         </property>
-        <property name="wordWrap">
-         <bool>true</bool>
+        <property name="flat">
+         <bool>false</bool>
         </property>
-        <property name="textInteractionFlags">
-         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </widget>
+      </item>
+      <item row="2" column="5">
+       <widget class="QLabel" name="label_11">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;fuel endurance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>hrs</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="5">
+       <widget class="QLabel" name="label_8">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;planned enroute time&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>hrs</string>
         </property>
        </widget>
       </item>
@@ -646,7 +452,41 @@ route</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1" colspan="3">
+      <item row="0" column="5">
+       <widget class="QLabel" name="label_5">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;S&lt;/span&gt;cheduled &lt;span style=&quot; font-weight:700;&quot;&gt;o&lt;/span&gt;ff &lt;span style=&quot; font-weight:700;&quot;&gt;b&lt;/span&gt;lock &lt;span style=&quot; font-weight:700;&quot;&gt;t&lt;/span&gt;ime&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>z</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="buttonDest">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>open destination aerodrome details dialog</string>
+        </property>
+        <property name="text">
+         <string>LOWI (Innsbruck, AT)</string>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1" colspan="5">
        <widget class="QLabel" name="lblRemarks">
         <property name="text">
          <string>&lt;code&gt;PBN/A1B1D1O1S2 NAV/RNVD1E2A1 DOF/220222 REG/DABVM EET/EDUU0013 LOVV0029 LJLA0039 LDZO0044 LQSB0054 LYBA0109 BKPR0117 LWSS0124 LGGG0133 LTBB0212 LGGG0217 LCCC0235 HECC0255 OJAC0325 OEJD0334 OBBB0447 OMAE0508 RMK/TCAS /V/&lt;/code&gt;</string>
@@ -658,6 +498,240 @@ route</string>
          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
         </property>
        </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;departure aerodrome&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>dep</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>filed &lt;b&gt;t&lt;/b&gt;rue &lt;b&gt;a&lt;/b&gt;ir&lt;b&gt;s&lt;/b&gt;peed / cruise level / &lt;b&gt;p&lt;/b&gt;lanned &lt;b&gt;t&lt;/b&gt;ime &lt;b&gt;e&lt;/b&gt;nroute</string>
+        </property>
+        <property name="text">
+         <string>TAS/FL</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="buttonFrom">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>open departure aerodrome details dialog</string>
+        </property>
+        <property name="text">
+         <string>LOWW (Vienna, AT)</string>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>route</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QLabel" name="lblPlanEtd">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;S&lt;/span&gt;cheduled &lt;span style=&quot; font-weight:700;&quot;&gt;o&lt;/span&gt;ff &lt;span style=&quot; font-weight:700;&quot;&gt;b&lt;/span&gt;lock &lt;span style=&quot; font-weight:700;&quot;&gt;t&lt;/span&gt;ime&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>1035</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QLabel" name="lblPlanEta">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;S&lt;/span&gt;cheduled &lt;span style=&quot; font-weight:700;&quot;&gt;t&lt;/span&gt;ime &lt;span style=&quot; font-weight:700;&quot;&gt;o&lt;/span&gt;f &lt;span style=&quot; font-weight:700;&quot;&gt;a&lt;/span&gt;rrival&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>1125</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="QLabel" name="lblPlanEte">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;planned enroute time&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>0:50</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="label_16">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;S&lt;/span&gt;cheduled &lt;span style=&quot; font-weight:700;&quot;&gt;o&lt;/span&gt;ff &lt;span style=&quot; font-weight:700;&quot;&gt;b&lt;/span&gt;lock &lt;span style=&quot; font-weight:700;&quot;&gt;t&lt;/span&gt;ime&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>SOBT</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QLabel" name="label_17">
+        <property name="font">
+         <font>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;S&lt;/span&gt;cheduled &lt;span style=&quot; font-weight:700;&quot;&gt;t&lt;/span&gt;ime &lt;span style=&quot; font-weight:700;&quot;&gt;o&lt;/span&gt;f &lt;span style=&quot; font-weight:700;&quot;&gt;a&lt;/span&gt;rrival&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>STA</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="label_18">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;fuel endurance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>fuel</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="lblPlanTas">
+          <property name="font">
+           <font>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>ICAO flightplan format for true airspeed (TAS)</string>
+          </property>
+          <property name="text">
+           <string>N420</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="lblPlanFl">
+          <property name="font">
+           <font>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>ICAO flightplan format for flight level</string>
+          </property>
+          <property name="text">
+           <string>F340</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_19">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;planned enroute time&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>enroute</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -709,7 +783,9 @@ route</string>
   <tabstop>buttonAddFriend</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../Resources.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonShowOnMap</sender>

--- a/src/models/AirportDetailsDeparturesModel.cpp
+++ b/src/models/AirportDetailsDeparturesModel.cpp
@@ -95,8 +95,8 @@ QVariant AirportDetailsDeparturesModel::data(const QModelIndex &index, int role)
                 return p->waypoints().isEmpty()? "": p->waypoints().constFirst();
             case 6:
                 if (p->flightStatus() == Pilot::PREFILED || p->flightStatus() == Pilot::BOARDING || p->flightStatus() == Pilot::GROUND_DEP) {
-                    return "PTD " + p->etd().toString("HH:mm"); // p->planDeptime.mid(0, p->planDeptime.length() - 2) +
-                                                                // ":" + p->planDeptime.right(2);
+                    return "SOBT " + p->etd().toString("HH:mm"); // p->planDeptime.mid(0, p->planDeptime.length() - 2) +
+                                                                 // ":" + p->planDeptime.right(2);
                 } else {
                     return QString("%1 NM").arg(p->distanceFromDeparture() < 3? 0: (int) p->distanceFromDeparture());
                 }


### PR DESCRIPTION
Our previous terminology was misleading.

Also our latest round of reading tea leaves has given us the impression that VATSIM might probably under circumstances inshallah refer to SOBT now in the flightplan form. SimBrief uses that field to prefill it with the SOBT as well.
It is still called `flightplan.deptime` in the status stream though. (?!)

Ref: https://github.com/orgs/vatsimnetwork/discussions/20