### PR TITLE
[TASK] Allow METAR request redirects

### DIFF
--- a/src/Net.cpp
+++ b/src/Net.cpp
@@ -24,22 +24,28 @@ Net::Net()
     }
 }
 
-QNetworkReply* Net::h(const QNetworkRequest &request) {
+QNetworkReply* Net::h(QNetworkRequest &request) {
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     return Net::instance()->head(request);
 }
 
 QNetworkReply* Net::g(const QUrl &url) {
-    return Net::instance()->get(QNetworkRequest(url));
-}
-
-QNetworkReply* Net::g(const QNetworkRequest &request) {
+    QNetworkRequest request(url);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     return Net::instance()->get(request);
 }
 
-QNetworkReply* Net::p(const QNetworkRequest &request, QIODevice* data) {
+QNetworkReply* Net::g(QNetworkRequest &request) {
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    return Net::instance()->get(request);
+}
+
+QNetworkReply* Net::p(QNetworkRequest &request, QIODevice* data) {
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     return Net::instance()->post(request, data);
 }
 
-QNetworkReply* Net::p(const QNetworkRequest &request, const QByteArray &data) {
+QNetworkReply* Net::p(QNetworkRequest &request, const QByteArray &data) {
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     return Net::instance()->post(request, data);
 }

--- a/src/Net.h
+++ b/src/Net.h
@@ -12,11 +12,11 @@ class Net
         Net();
 
         // convenience functions: Net::g() vs. Net::instance()->get()
-        static QNetworkReply* h(const QNetworkRequest &request);
+        static QNetworkReply* h(QNetworkRequest &request);
         static QNetworkReply* g(const QUrl &url);
-        static QNetworkReply* g(const QNetworkRequest &request);
-        static QNetworkReply* p(const QNetworkRequest &request, QIODevice* data);
-        static QNetworkReply* p(const QNetworkRequest &request, const QByteArray &data);
+        static QNetworkReply* g(QNetworkRequest &request);
+        static QNetworkReply* p(QNetworkRequest &request, QIODevice* data);
+        static QNetworkReply* p(QNetworkRequest &request, const QByteArray &data);
 };
 
 #endif // NET_H

--- a/src/models/MetarModel.h
+++ b/src/models/MetarModel.h
@@ -32,6 +32,7 @@ class MetarModel
 
     private slots:
         void metarReplyFinished();
+        void metarReplyRedirected(const QUrl&);
         void gotMetarFor(Airport* airport);
 
     private:


### PR DESCRIPTION
Recently a change on VATSIM side added a 301 HTTP redirect when METARs
are requested (this has not been reflected yet in status.vatsim.net
unfortunately).

Fixes: #355 
