### PR TITLE
[BUGFIX] Add SplashScreen type to Launcher widget

### DIFF
--- a/src/Launcher.cpp
+++ b/src/Launcher.cpp
@@ -20,7 +20,7 @@ Launcher* Launcher::instance(bool createIfNoInstance) {
 
 Launcher::Launcher(QWidget* parent)
     : QWidget(parent,
-          Qt::FramelessWindowHint | Qt::WindowSystemMenuHint) {
+          Qt::SplashScreen | Qt::FramelessWindowHint | Qt::WindowSystemMenuHint) {
     _map = QPixmap(":/startup/logo").scaled(600, 600);
     resize(_map.width(), _map.height());
     move(


### PR DESCRIPTION
Without this type, the launcher widget is not displayed centered when using a tiling window manager (tested with bspwm on Linux).

The ``Qt::SplashScreen`` type is also the default type for the ``QSplashScreen`` widget. Perhaps in the future, ``Launcher`` could directly inherit from ``QSplashScreen`` for simplification.
